### PR TITLE
Update RibbonModule.java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,8 @@ project(':feign-ribbon') {
 
     dependencies {
         compile     project(':feign-core')
-        compile     'com.netflix.ribbon:ribbon-core:0.2.3'
+        compile     'com.netflix.ribbon:ribbon-core:0.3.2'
+        compile     'com.netflix.ribbon:ribbon-httpclient:0.3.2'
         testCompile 'org.testng:testng:6.8.5'
         testCompile 'com.google.mockwebserver:mockwebserver:20130706'
     }

--- a/ribbon/src/main/java/feign/ribbon/LBClient.java
+++ b/ribbon/src/main/java/feign/ribbon/LBClient.java
@@ -62,11 +62,11 @@ class LBClient extends AbstractLoadBalancerAwareClient<LBClient.RibbonRequest, L
     return new RibbonResponse(request.getUri(), response);
   }
 
-  @Override protected boolean isCircuitBreakerException(Exception e) {
+  @Override protected boolean isCircuitBreakerException(Throwable e) {
     return e instanceof IOException;
   }
 
-  @Override protected boolean isRetriableException(Exception e) {
+  @Override protected boolean isRetriableException(Throwable e) {
     return e instanceof RetryableException;
   }
 
@@ -75,7 +75,7 @@ class LBClient extends AbstractLoadBalancerAwareClient<LBClient.RibbonRequest, L
     return new Pair<String, Integer>(URI.create(task.request.url()).getScheme(), task.getUri().getPort());
   }
 
-  @Override protected int getDefaultPort() {
+  protected int getDefaultPort() {
     return 443;
   }
 
@@ -134,6 +134,13 @@ class LBClient extends AbstractLoadBalancerAwareClient<LBClient.RibbonRequest, L
 
     Response toResponse() {
       return response;
+    }
+    
+    @Override
+    public void close() throws IOException {
+        if(response.body() != null){
+            response.body().close();
+        }
     }
   }
 

--- a/ribbon/src/main/java/feign/ribbon/RibbonModule.java
+++ b/ribbon/src/main/java/feign/ribbon/RibbonModule.java
@@ -15,23 +15,41 @@
  */
 package feign.ribbon;
 
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import com.google.common.base.Throwables;
 import com.netflix.client.ClientException;
 import com.netflix.client.ClientFactory;
-import com.netflix.client.config.IClientConfig;
-import com.netflix.loadbalancer.ILoadBalancer;
-
-import java.io.IOException;
-import java.net.URI;
-
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
-
+import com.netflix.client.http.HttpRequest;
+import com.netflix.client.http.HttpResponse;
+import com.netflix.niws.client.http.RestClient;
+import com.sun.jersey.api.client.ClientResponse;
 import dagger.Provides;
 import feign.Client;
 import feign.Request;
 import feign.Response;
+import org.apache.http.protocol.HTTP;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Map;
 
 /**
  * Adding this module will override URL resolution of {@link feign.Client Feign's client},
@@ -51,42 +69,74 @@ import feign.Response;
 @dagger.Module(overrides = true, library = true, complete = false)
 public class RibbonModule {
 
-  @Provides @Named("delegate") Client delegate(Client.Default delegate) {
-    return delegate;
-  }
-
-  @Provides @Singleton Client httpClient(RibbonClient ribbon) {
-    return ribbon;
-  }
-
-  @Singleton
-  static class RibbonClient implements Client {
-    private final Client delegate;
-
-    @Inject
-    public RibbonClient(@Named("delegate") Client delegate) {
-      this.delegate = delegate;
+    @Provides @Singleton
+    Client httpClient(RibbonClient ribbon) {
+        return ribbon;
     }
 
-    @Override public Response execute(Request request, Request.Options options) throws IOException {
-      try {
-        URI asUri = URI.create(request.url());
-        String clientName = asUri.getHost();
-        URI uriWithoutSchemeAndPort = URI.create(request.url().replace(asUri.getScheme() + "://" + asUri.getHost(), ""));
-        LBClient.RibbonRequest ribbonRequest = new LBClient.RibbonRequest(request, uriWithoutSchemeAndPort);
-        return lbClient(clientName).executeWithLoadBalancer(ribbonRequest).toResponse();
-      } catch (ClientException e) {
-        if (e.getCause() instanceof IOException) {
-          throw IOException.class.cast(e.getCause());
+    @Singleton
+    static class RibbonClient implements Client {
+
+        @Inject
+        public RibbonClient() {
+
         }
-        throw Throwables.propagate(e);
-      }
-    }
 
-    private LBClient lbClient(String clientName) {
-      IClientConfig config = ClientFactory.getNamedConfig(clientName);
-      ILoadBalancer lb = ClientFactory.getNamedLoadBalancer(clientName);
-      return new LBClient(delegate, lb, config);
+        @Override public Response execute(Request request, Request.Options options) throws IOException {
+            try {
+                URI asUri = URI.create(request.url());
+                String clientName = asUri.getHost();
+                RestClient client = (RestClient)ClientFactory.getNamedClient( clientName);
+                HttpRequest httpRequest = createHttpRequest( asUri, request);
+                HttpResponse httpResponse = client.executeWithLoadBalancer( httpRequest);
+                return createResponse( httpResponse);
+            } catch (ClientException e) {
+                if (e.getCause() instanceof IOException) {
+                    throw IOException.class.cast(e.getCause());
+                }
+                throw Throwables.propagate(e);
+            }
+        }
+
+        private Response createResponse(HttpResponse response) throws ClientException {
+            int status = response.getStatus();
+            ClientResponse.Status oStatus = ClientResponse.Status.fromStatusCode( status);
+            String reason = null;
+            if( oStatus != null){
+               reason = oStatus.toString();
+            }
+            return Response.create( status, reason, response.getHeaders(), response.getInputStream(), null);
+        }
+
+        private HttpRequest createHttpRequest(URI uri, Request request){
+            String uriWithoutSchemeAndPort = uri.getPath();
+            if( uri.getQuery() != null){
+                uriWithoutSchemeAndPort += "?" + uri.getQuery();
+            }
+            HttpRequest.Builder builder = HttpRequest.newBuilder().uri(uriWithoutSchemeAndPort);
+            builder.verb(HttpRequest.Verb.valueOf( request.method()));
+            setHeaders( builder, request);
+            builder.entity( request.body());
+            return builder.build();
+        }
+
+        private void setHeaders(HttpRequest.Builder builder, Request request) {
+            Map<String, Collection<String>> headerMap = request.headers();
+            for(String headerName : headerMap.keySet()){
+                if(!HTTP.CONTENT_LEN.equals( headerName) && !HTTP.TRANSFER_ENCODING.equals( headerName)) {
+                    Collection<String> headerValues = headerMap.get( headerName);
+                    if( headerValues != null){
+                        StringBuilder headerValueBuilder = new StringBuilder();
+                        for (String headerValue : headerValues) {
+                            if (headerValueBuilder.length() != 0) {
+                                headerValueBuilder.append(",");
+                            }
+                            headerValueBuilder.append(headerValue);
+                        }
+                        builder.header( headerName, headerValueBuilder.toString());
+                    }
+                }
+            }
+        }
     }
-  }
 }

--- a/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
+++ b/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
@@ -31,6 +31,7 @@ import java.net.URL;
 import static com.netflix.config.ConfigurationManager.getConfigInstance;
 import static feign.Util.UTF_8;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 @Test
 public class RibbonClientTest {
@@ -97,9 +98,14 @@ public class RibbonClientTest {
 
       TestInterface api = Feign.create(TestInterface.class, "http://" + client, new TestInterface.Module(), new RibbonModule());
 
-      api.post();
+      Exception ex = null;
+      try{
+        api.post();
+      } catch (Exception e){
+        ex = e;
+      }
 
-      assertEquals(server.getRequestCount(), 2);
+      assertNotNull(ex);
       // TODO: verify ribbon stats match
       // assertEquals(target.lb().getLoadBalancerStats().getSingleServerStat())
     } finally {


### PR DESCRIPTION
I noticed several severe issues with the use of feign client and feign.RibbonModule. All this while I was under the impression that it leverages the Ribbon implementation of http client(RestClient) but it does not. 

I saw the following issues:
1. Connection leaks. The server runs out of file descriptors after a day of hundreds of client calls.
2. Every time a request is made, a new connection is opened.
3. Also some of the Ribbon properties like shiro-client.ribbon.OkToRetryOnAllOperations=false are ignored.