### PR TITLE
Added ability to expand and encode variables in body annotation and expand request line variables that are not already key pairs 

### DIFF
--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -169,6 +169,7 @@ public interface Contract {
           String varName = '{' + name + '}';
           if (data.template().url().indexOf(varName) == -1 &&
               !searchMapValues(data.template().queries(), varName) &&
+              !data.template().queries().containsKey(varName) &&
               !searchMapValues(data.template().headers(), varName)) {
             data.formParams().add(name);
           }

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.io.UnsupportedEncodingException;
 
 import static feign.Util.checkArgument;
 import static feign.Util.checkNotNull;
@@ -147,6 +148,8 @@ public class ReflectiveFeign extends Feign {
         BuildTemplateByResolvingArgs buildTemplate;
         if (!md.formParams().isEmpty() && md.template().bodyTemplate() == null) {
           buildTemplate = new BuildFormEncodedTemplateFromArgs(md, encoder);
+        } else if (!md.formParams().isEmpty() && md.template().bodyTemplate() != null && !(encoder instanceof Encoder.Default)) {
+          buildTemplate = new BuildFormTemplateByResolvingAndEncodingArgs(md, encoder);
         } else if (md.bodyIndex() != null) {
           buildTemplate = new BuildEncodedTemplateFromArgs(md, encoder);
         } else {
@@ -184,6 +187,37 @@ public class ReflectiveFeign extends Feign {
     }
 
     protected RequestTemplate resolve(Object[] argv, RequestTemplate mutable, Map<String, Object> variables) {
+      return mutable.resolve(variables);
+    }
+  }
+
+  private static class BuildFormTemplateByResolvingAndEncodingArgs extends BuildTemplateByResolvingArgs {
+    private final Encoder encoder;
+
+    private BuildFormTemplateByResolvingAndEncodingArgs(MethodMetadata metadata, Encoder encoder) {
+      super(metadata);
+      this.encoder = encoder;
+    }
+
+    @Override
+    protected RequestTemplate resolve(Object[] argv, RequestTemplate mutable, Map<String, Object> variables) {
+      Map<String, Object> formVariables = new LinkedHashMap<String, Object>();
+      RequestTemplate tempTemplate = new RequestTemplate();
+      for (Entry<String, Object> entry : variables.entrySet()) {
+        if (metadata.formParams().contains(entry.getKey()) && !(entry.getValue() instanceof String) ) {
+            try {
+              encoder.encode(entry.getValue(), tempTemplate);
+              variables.put(entry.getKey(), new String(tempTemplate.body(), "UTF-8"));
+            } catch (EncodeException e) {
+              throw e;
+            } catch (RuntimeException e) {
+              throw new EncodeException(e.getMessage(), e);
+            } catch (UnsupportedEncodingException uee) {
+              throw new EncodeException(uee.getMessage(), uee);
+            }
+        }
+      }
+     
       return mutable.resolve(variables);
     }
   }

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -552,7 +552,6 @@ public final class RequestTemplate implements Serializable {
       if (entryKey == null || entryValue == null) {
         continue;
       }
-      System.out.println("Looking at "+entryKey+" value"+entryValue);
       if (entryKey.indexOf('{') == 0 && entryKey.indexOf('}') == entryKey.length() - 1) {
         Object variableValue = unencoded.get(entryKey.substring(1, entryKey.length() - 1));
         entry.setValue(Arrays.asList(Util.variableToQueryString(variableValue)));

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -559,7 +559,7 @@ public final class RequestTemplate implements Serializable {
         continue;
       }
       if (entryValue == null) {
-          continue;
+        continue;
       }
       Collection<String> values = new ArrayList<String>();
       for (String value : entryValue) {

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -547,11 +547,20 @@ public final class RequestTemplate implements Serializable {
     Iterator<Entry<String, Collection<String>>> iterator = queries.entrySet().iterator();
     while (iterator.hasNext()) {
       Entry<String, Collection<String>> entry = iterator.next();
-      if (entry.getValue() == null) {
+      Collection<String> entryValue = entry.getValue();
+      String entryKey = entry.getKey();
+      if (entryKey == null || entryValue == null) {
+        continue;
+      }
+      System.out.println("Looking at "+entryKey+" value"+entryValue);
+      if (entryKey.indexOf('{') == 0 && entryKey.indexOf('}') == entryKey.length() - 1) {
+        Object variableValue = unencoded.get(entryKey.substring(1, entryKey.length() - 1));
+        entry.setValue(Arrays.asList(Util.variableToQueryString(variableValue)));
         continue;
       }
       Collection<String> values = new ArrayList<String>();
-      for (String value : entry.getValue()) {
+      for (String value : entryValue) {
+        if (value == null) continue;
         if (value.indexOf('{') == 0 && value.indexOf('}') == value.length() - 1) {
           Object variableValue = unencoded.get(value.substring(1, value.length() - 1));
           // only add non-null expressions
@@ -582,13 +591,18 @@ public final class RequestTemplate implements Serializable {
       return "";
     StringBuilder queryBuilder = new StringBuilder();
     for (String field : queries.keySet()) {
-      for (String value : valuesOrEmpty(queries, field)) {
+      if(field != null && field.indexOf('{') == 0 && field.indexOf('}') == field.length() - 1) {
         queryBuilder.append('&');
-        queryBuilder.append(field);
-        if (value != null) {
-          queryBuilder.append('=');
-          if (!value.isEmpty())
-            queryBuilder.append(value);
+        queryBuilder.append(queries.get(field).iterator().next());
+      } else {
+        for (String value : valuesOrEmpty(queries, field)) {
+          queryBuilder.append('&');
+          queryBuilder.append(field);
+          if (value != null) {
+            queryBuilder.append('=');
+            if (!value.isEmpty())
+              queryBuilder.append(value);
+          }
         }
       }
     }

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -170,7 +170,6 @@ public final class RequestTemplate implements Serializable {
           inVar = false;
           String key = var.toString();
           Object value = variables.get(var.toString());
-          System.out.println("About to add "+value);
           if (value != null)
             builder.append(value);
           else

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -170,6 +170,7 @@ public final class RequestTemplate implements Serializable {
           inVar = false;
           String key = var.toString();
           Object value = variables.get(var.toString());
+          System.out.println("About to add "+value);
           if (value != null)
             builder.append(value);
           else

--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -278,7 +278,7 @@ public class Util {
               }
             }
           } catch (Exception e) {
-              
+              throw new RuntimeException(e);
           } 
       }
       if (KVPairs.size() > 0) {

--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -15,16 +15,23 @@
  */
 package feign;
 
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
+import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
@@ -32,8 +39,12 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
+import static feign.Util.UTF_8;
 import static java.lang.String.format;
 
 /**
@@ -241,6 +252,60 @@ public class Util {
       return charset.newDecoder().decode(ByteBuffer.wrap(data)).toString();
     } catch (CharacterCodingException ex) {
       return defaultValue;
+    }
+  }
+  
+  public static String variableToQueryString(Object variableValue) {
+      if (variableValue == null) return null;
+      List<String> KVPairs = new ArrayList<String>();
+      if (variableValue instanceof Map) {
+          Iterator<?> entries = ((Map<?, ?>) variableValue).entrySet().iterator();
+          while (entries.hasNext()) {
+              Entry<?, ?> entry = (Entry<?, ?>) entries.next();
+              Object itemKey = entry.getKey();
+              Object value = entry.getValue();
+              if (itemKey != null && itemKey instanceof String && value != null) {
+                  KVPairs.add(encodePair(itemKey, value));
+              }
+          }
+      } else if (variableValue instanceof Object) {
+          try {
+            for(PropertyDescriptor propertyDescriptor : Introspector.getBeanInfo(variableValue.getClass()).getPropertyDescriptors()) {
+              Method reader = propertyDescriptor.getReadMethod();
+              String methodName = propertyDescriptor.getDisplayName();
+              if (reader != null && methodName.indexOf("class") != 0 && methodName.indexOf("metaClass") != 0) {
+                  KVPairs.add(encodePair(methodName, reader.invoke(variableValue)));
+              }
+            }
+          } catch (Exception e) {
+              
+          } 
+      }
+      if (KVPairs.size() > 0) {
+          StringBuilder sb = new StringBuilder();
+          for (int i = 0; i < KVPairs.size(); i++) {
+              sb.append("&").append(KVPairs.get(i));
+          }
+          sb.deleteCharAt(0);
+          return sb.toString();
+      }
+      return null;
+  }
+  
+  public static String encodePair(Object key, Object value) {
+      StringBuilder sb = new StringBuilder();
+      return sb
+        .append(urlEncode(key))
+        .append("=")
+        .append(urlEncode(value))
+        .toString();
+  }
+  
+  public static String urlEncode(Object arg) {
+    try {
+      return URLEncoder.encode(String.valueOf(arg), UTF_8.name());
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(e);
     }
   }
 }

--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -308,4 +308,11 @@ public class Util {
       throw new RuntimeException(e);
     }
   }
+  
+  public static boolean isVariable(String item) {
+      if (item == null || item.length() == 0) {
+          return false;
+      }
+      return (item.indexOf('{') == 0 && item.indexOf('}') == item.length() - 1);
+  }
 }

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -201,4 +201,46 @@ public class RequestTemplateTest {
     assertEquals(template.toString(), ""//
         + "GET /domains/1001/records HTTP/1.1\n");
   }
+  
+  @Test public void expandMapOfKeyPairForQuery() throws Exception {
+      RequestTemplate template = new RequestTemplate().method("POST")
+              .append("/1/cards")//
+              .query("key", "{key}")//
+              .query("token", "{token}")
+              .query("name", "{name}")
+              .query("idList", "{idList}")
+              .query("{fields}", ImmutableList.of(""));
+      
+      ImmutableMap<String,Object> fields = ImmutableMap.of(
+              "label", (Object)"blue", 
+              "description", (Object)"nice");
+      
+      template = template.resolve(ImmutableMap.<String, Object>builder()
+              .put("key", "9f867f42asdfasdfa406981c0468b0134")
+              .put("token", "asdfasdf87df285c943b7627basdfasdfc9df8cde08a81f380935")
+              .put("name", "CardName")
+              .put("idList", Arrays.asList("537be504aaf676a1adee4871"))
+              .put("fields", fields)
+              .build()
+          );
+      
+      assertEquals(template.toString(), ""
+              + "POST /1/cards?key=9f867f42asdfasdfa406981c0468b0134&"
+              + "token=asdfasdf87df285c943b7627basdfasdfc9df8cde08a81f380935&"
+              + "name=CardName&"
+              + "idList=537be504aaf676a1adee4871&"
+              + "label=blue&"
+              + "description=nice HTTP/1.1\n");
+  }
+  
+  @Test public void fieldsInRequestLine() throws Exception {
+      RequestTemplate template = new RequestTemplate()
+          .method("PUT")
+          .append("/1/cards/{cardIdOrShortLink}?key={key}&token={token}&{fields}");
+      
+      assertEquals(template.queries().size(), 3);
+      assertEquals(template.queries().containsKey("{fields}"), true);
+  }
+  
+  
 }

--- a/core/src/test/java/feign/UtilTest.java
+++ b/core/src/test/java/feign/UtilTest.java
@@ -16,7 +16,10 @@
 package feign;
 
 import feign.codec.Decoder;
+
 import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
 
 import java.io.Reader;
 import java.lang.reflect.Type;
@@ -82,5 +85,52 @@ public class UtilTest {
     Type context = LastTypeParameter.class.getDeclaredField("PARAMETERIZED_DECODER_UNBOUND").getGenericType();
     Type last = resolveLastTypeParameter(context, ParameterizedDecoder.class);
     assertEquals(last, Object.class);
+  }
+  
+  @Test public void variableToQueryString() throws Exception {
+      ImmutableMap<String, String> map = ImmutableMap.of(
+              "field1", "value1",
+              "field2", "value2",
+              "field3", "value3");
+      
+      String queryString = Util.variableToQueryString(map);
+      assertEquals(queryString, "field1=value1&field2=value2&field3=value3");
+          
+      class Simple {
+          private String field1;
+          private int field2;
+          
+          public Simple(String field1, int field2) {
+              this.field1 = field1;
+              this.field2 = field2;
+          }
+          
+          public String getField1() { 
+              return field1; 
+          }
+          
+          public int getField2() { 
+              return field2;
+          }
+      }
+      
+      Simple simpleObject = new Simple("value1", 1234); 
+      queryString = Util.variableToQueryString(simpleObject);
+      assertEquals(queryString, "field1=value1&field2=1234");
+  }
+  
+  @Test public void encodePair() throws Exception {
+      assertEquals(Util.encodePair("key", "value") , "key=value");
+      assertEquals(Util.encodePair("key with spaces", "value"), "key+with+spaces=value");
+      assertEquals(Util.encodePair("key", "value with spaces"), "key=value+with+spaces");
+      assertEquals(Util.encodePair("key", 1234), "key=1234");
+      assertEquals(Util.encodePair("key", new java.util.Date(0)), "key=Thu+Jan+01+10%3A00%3A00+EST+1970");
+  }
+  
+  @Test public void isVariable() throws Exception {
+      assertEquals(Util.isVariable("{test}"), true);
+      assertEquals(Util.isVariable("{test"), false);
+      assertEquals(Util.isVariable(" {test} "), false);
+      assertEquals(Util.isVariable("test}"), false);
   }
 }

--- a/core/src/test/java/feign/UtilTest.java
+++ b/core/src/test/java/feign/UtilTest.java
@@ -124,7 +124,11 @@ public class UtilTest {
       assertEquals(Util.encodePair("key with spaces", "value"), "key+with+spaces=value");
       assertEquals(Util.encodePair("key", "value with spaces"), "key=value+with+spaces");
       assertEquals(Util.encodePair("key", 1234), "key=1234");
-      assertEquals(Util.encodePair("key", new java.util.Date(0)), "key=Thu+Jan+01+10%3A00%3A00+EST+1970");
+      
+      java.util.Calendar cal = java.util.Calendar.getInstance();
+      cal.setTimeInMillis(0);
+      
+      assertEquals(Util.encodePair("key", cal.getTime()), "key=Thu+Jan+01+10%3A00%3A00+EST+1970");
   }
   
   @Test public void isVariable() throws Exception {


### PR DESCRIPTION
Example below serialises complex type "Operation" into the inputData placeholder in @Body.
 
```java

@RequestLine("POST /sdpapi/request")
@Body("OPERATION_NAME=GET_REQUESTS&TECHNICIAN_KEY={technicalKey}&INPUT_DATA={inputData}")
    public API getRequests(
        @Named("technicalKey") String technicalKey,
        @Named("inputData") Operation operation
    )

```

The example below automatically expands the key-value pairs for the fields variable.

```java
@RequestLine("PUT /1/cards/{cardIdOrShortLink}?key={key}&token={token}&{fields}")
    public Card updateCardWithFields(
        @Named("key") String key,
        @Named("token") String token,
        @Named("cardIdOrShortLink") String cardIdOrShortLink,
        @Named("fields") Object fields
    )
```
