### PR TITLE
Introduces feign.Param to annotate template parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 7.1
+* Introduces feign.@Param to annotate template parameters. Users must migrate from `javax.inject.@Named` to `feign.@Param` before updating to Feign 8.0.
+
 ### Version 7.0
 * Expose reflective dispatch hook: InvocationHandlerFactory
 * Add JAXB integration

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Usage typically looks like this, an adaptation of the [canonical Retrofit sample
 ```java
 interface GitHub {
   @RequestLine("GET /repos/{owner}/{repo}/contributors")
-  List<Contributor> contributors(@Named("owner") String owner, @Named("repo") String repo);
+  List<Contributor> contributors(@Param("owner") String owner, @Param("repo") String repo);
 }
 
 static class Contributor {
@@ -44,7 +44,7 @@ Feign has several aspects that can be customized.  For simple cases, you can use
 ```java
 interface Bank {
   @RequestLine("POST /account/{id}")
-  Account getAccountInfo(@Named("id") String id);
+  Account getAccountInfo(@Param("id") String id);
 }
 ...
 Bank bank = Feign.builder().decoder(new AccountDecoder()).target(Bank.class, "https://api.examplebank.com");

--- a/core/src/main/java/feign/Body.java
+++ b/core/src/main/java/feign/Body.java
@@ -15,7 +15,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <br>
  * <pre>
  * &#064;Body(&quot;&lt;v01:getResourceRecordsOfZone&gt;&lt;zoneName&gt;{zoneName}&lt;/zoneName&gt;&lt;rrType&gt;0&lt;/rrType&gt;&lt;/v01:getResourceRecordsOfZone&gt;&quot;)
- * List&lt;Record&gt; listByZone(&#64;Named(&quot;zoneName&quot;) String zoneName);
+ * List&lt;Record&gt; listByZone(&#64;Param(&quot;zoneName&quot;) String zoneName);
  * </pre>
  * <br>
  * Note that if you'd like curly braces literally in the body, urlencode

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -159,11 +159,12 @@ public interface Contract {
     @Override
     protected boolean processAnnotationsOnParameter(MethodMetadata data, Annotation[] annotations, int paramIndex) {
       boolean isHttpAnnotation = false;
-      for (Annotation parameterAnnotation : annotations) {
-        Class<? extends Annotation> annotationType = parameterAnnotation.annotationType();
-        if (annotationType == Named.class) {
-          String name = Named.class.cast(parameterAnnotation).value();
-          checkState(emptyToNull(name) != null, "Named annotation was empty on param %s.", paramIndex);
+      for (Annotation annotation : annotations) {
+        Class<? extends Annotation> annotationType = annotation.annotationType();
+        if (annotationType == Param.class || annotationType == Named.class) {
+          String name = annotationType == Param.class ? ((Param) annotation).value() : ((Named) annotation).value();
+          checkState(emptyToNull(name) != null,
+              "%s annotation was empty on param %s.", annotationType.getSimpleName(), paramIndex);
           nameParam(data, name, paramIndex);
           isHttpAnnotation = true;
           String varName = '{' + name + '}';

--- a/core/src/main/java/feign/Headers.java
+++ b/core/src/main/java/feign/Headers.java
@@ -18,7 +18,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * &#64;Headers({
  *   "X-Foo: Bar",
  *   "X-Ping: {token}"
- * }) void post(&#64;Named("token") String token);
+ * }) void post(&#64;Param("token") String token);
  * ...
  * </pre>
  * <br>

--- a/core/src/main/java/feign/Param.java
+++ b/core/src/main/java/feign/Param.java
@@ -13,13 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package feign.assertj;
+package feign;
 
-import feign.RequestTemplate;
-import org.assertj.core.api.Assertions;
+import java.lang.annotation.Retention;
 
-public class FeignAssertions extends Assertions {
-  public static RequestTemplateAssert assertThat(RequestTemplate actual) {
-    return new RequestTemplateAssert(actual);
-  }
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/** The name of a template variable applied to {@link Headers},  {@linkplain RequestLine} or {@linkplain Body} */
+@Retention(RUNTIME)
+@java.lang.annotation.Target(PARAMETER)
+public @interface Param {
+  String value();
 }

--- a/core/src/main/java/feign/RequestLine.java
+++ b/core/src/main/java/feign/RequestLine.java
@@ -15,7 +15,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * ...
  *
  * &#64;RequestLine("GET /servers/{serverId}?count={count}")
- * void get(&#64;Named("serverId") String serverId, &#64;Named("count") int count);
+ * void get(&#64;Param("serverId") String serverId, &#64;Param("count") int count);
  * ...
  *
  * &#64;RequestLine("GET")
@@ -39,7 +39,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Feign:
  * <pre>
  * &#64;RequestLine("GET /servers/{serverId}?count={count}")
- * void get(&#64;Named("serverId") String serverId, &#64;Named("count") int count);
+ * void get(&#64;Param("serverId") String serverId, &#64;Param("count") int count);
  * ...
  * </pre>
  * <br>

--- a/core/src/main/java/feign/codec/Encoder.java
+++ b/core/src/main/java/feign/codec/Encoder.java
@@ -55,7 +55,7 @@ import static java.lang.String.format;
  * <pre>
  * &#064;POST
  * &#064;Path(&quot;/&quot;)
- * Session login(@Named(&quot;username&quot;) String username, @Named(&quot;password&quot;) String password);
+ * Session login(@Param(&quot;username&quot;) String username, @Param(&quot;password&quot;) String password);
  * </pre>
  */
 public interface Encoder {

--- a/core/src/test/java/feign/LoggerTest.java
+++ b/core/src/test/java/feign/LoggerTest.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import javax.inject.Named;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,8 +46,8 @@ public class LoggerTest {
     @Headers("Content-Type: application/json")
     @Body("%7B\"customer_name\": \"{customer_name}\", \"user_name\": \"{user_name}\", \"password\": \"{password}\"%7D")
     String login(
-        @Named("customer_name") String customer,
-        @Named("user_name") String user, @Named("password") String password);
+        @Param("customer_name") String customer,
+        @Param("user_name") String user, @Param("password") String password);
   }
 
   @RunWith(Parameterized.class)

--- a/core/src/test/java/feign/assertj/MockWebServerAssertions.java
+++ b/core/src/test/java/feign/assertj/MockWebServerAssertions.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package feign.assertj;
 
 import com.squareup.okhttp.mockwebserver.RecordedRequest;

--- a/core/src/test/java/feign/assertj/RecordedRequestAssert.java
+++ b/core/src/test/java/feign/assertj/RecordedRequestAssert.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package feign.assertj;
 
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
@@ -16,7 +31,6 @@ import org.assertj.core.internal.Objects;
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 
 public final class RecordedRequestAssert extends AbstractAssert<RecordedRequestAssert, RecordedRequest> {
-
   ByteArrays arrays = ByteArrays.instance();
   Objects objects = Objects.instance();
   Iterables iterables = Iterables.instance();

--- a/core/src/test/java/feign/assertj/RequestTemplateAssert.java
+++ b/core/src/test/java/feign/assertj/RequestTemplateAssert.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package feign.assertj;
 
 import feign.RequestTemplate;
@@ -10,7 +25,6 @@ import org.assertj.core.internal.Objects;
 import static feign.Util.UTF_8;
 
 public final class RequestTemplateAssert extends AbstractAssert<RequestTemplateAssert, RequestTemplate> {
-
   ByteArrays arrays = ByteArrays.instance();
   Objects objects = Objects.instance();
   Maps maps = Maps.instance();

--- a/core/src/test/java/feign/examples/GitHubExample.java
+++ b/core/src/test/java/feign/examples/GitHubExample.java
@@ -19,11 +19,11 @@ import com.google.gson.Gson;
 import com.google.gson.JsonIOException;
 import feign.Feign;
 import feign.Logger;
+import feign.Param;
 import feign.RequestLine;
 import feign.Response;
 import feign.codec.Decoder;
 
-import javax.inject.Named;
 import java.io.IOException;
 import java.io.Reader;
 import java.lang.reflect.Type;
@@ -38,7 +38,7 @@ public class GitHubExample {
 
   interface GitHub {
     @RequestLine("GET /repos/{owner}/{repo}/contributors")
-    List<Contributor> contributors(@Named("owner") String owner, @Named("repo") String repo);
+    List<Contributor> contributors(@Param("owner") String owner, @Param("repo") String repo);
   }
 
   static class Contributor {

--- a/gson/src/test/java/feign/gson/examples/GitHubExample.java
+++ b/gson/src/test/java/feign/gson/examples/GitHubExample.java
@@ -16,10 +16,10 @@
 package feign.gson.examples;
 
 import feign.Feign;
+import feign.Param;
 import feign.RequestLine;
 import feign.gson.GsonDecoder;
 
-import javax.inject.Named;
 import java.util.List;
 
 /**
@@ -29,7 +29,7 @@ public class GitHubExample {
 
   interface GitHub {
     @RequestLine("GET /repos/{owner}/{repo}/contributors")
-    List<Contributor> contributors(@Named("owner") String owner, @Named("repo") String repo);
+    List<Contributor> contributors(@Param("owner") String owner, @Param("repo") String repo);
   }
 
   static class Contributor {

--- a/jackson/src/test/java/feign/jackson/examples/GitHubExample.java
+++ b/jackson/src/test/java/feign/jackson/examples/GitHubExample.java
@@ -1,10 +1,10 @@
 package feign.jackson.examples;
 
 import feign.Feign;
+import feign.Param;
 import feign.RequestLine;
 import feign.jackson.JacksonDecoder;
 
-import javax.inject.Named;
 import java.util.List;
 
 /**
@@ -13,7 +13,7 @@ import java.util.List;
 public class GitHubExample {
   interface GitHub {
     @RequestLine("GET /repos/{owner}/{repo}/contributors")
-    List<Contributor> contributors(@Named("owner") String owner, @Named("repo") String repo);
+    List<Contributor> contributors(@Param("owner") String owner, @Param("repo") String repo);
   }
 
   static class Contributor {

--- a/ribbon/src/main/java/feign/ribbon/RibbonModule.java
+++ b/ribbon/src/main/java/feign/ribbon/RibbonModule.java
@@ -15,15 +15,10 @@
  */
 package feign.ribbon;
 
-import java.io.IOException;
-import java.net.URI;
-
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import dagger.Provides;
 import feign.Client;
+import javax.inject.Named;
+import javax.inject.Singleton;
 
 /**
  * Adding this module will override URL resolution of {@link feign.Client Feign's client},

--- a/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
+++ b/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
@@ -20,6 +20,7 @@ import com.squareup.okhttp.mockwebserver.SocketPolicy;
 import com.squareup.okhttp.mockwebserver.rule.MockWebServerRule;
 import dagger.Provides;
 import feign.Feign;
+import feign.Param;
 import feign.RequestLine;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
@@ -30,7 +31,6 @@ import java.net.URL;
 import static com.netflix.config.ConfigurationManager.getConfigInstance;
 import static org.junit.Assert.assertEquals;
 
-import javax.inject.Named;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,7 +43,7 @@ public class RibbonClientTest {
 
   interface TestInterface {
     @RequestLine("POST /") void post();
-    @RequestLine("GET /?a={a}") void getWithQueryParameters(@Named("a") String a);
+    @RequestLine("GET /?a={a}") void getWithQueryParameters(@Param("a") String a);
 
     @dagger.Module(injects = Feign.class, overrides = true, addsTo = Feign.Defaults.class)
     static class Module {
@@ -63,7 +63,8 @@ public class RibbonClientTest {
 
     getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.getUrl("")) + "," + hostAndPort(server2.getUrl("")));
 
-    TestInterface api = Feign.create(TestInterface.class, "http://" + client(), new TestInterface.Module(), new RibbonModule());
+    TestInterface api = Feign.create(TestInterface.class, "http://" + client(), new TestInterface.Module(),
+        new RibbonModule());
 
     api.post();
     api.post();
@@ -81,7 +82,8 @@ public class RibbonClientTest {
     getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.getUrl("")));
 
 
-    TestInterface api = Feign.create(TestInterface.class, "http://" + client(), new TestInterface.Module(), new RibbonModule());
+    TestInterface api = Feign.create(TestInterface.class, "http://" + client(), new TestInterface.Module(),
+        new RibbonModule());
 
     api.post();
 
@@ -105,7 +107,8 @@ public class RibbonClientTest {
 
 		getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.getUrl("")));
 
-    TestInterface api = Feign.create(TestInterface.class, "http://" + client(), new TestInterface.Module(), new RibbonModule());
+    TestInterface api = Feign.create(TestInterface.class, "http://" + client(), new TestInterface.Module(),
+        new RibbonModule());
 
     api.getWithQueryParameters(queryStringValue);
 


### PR DESCRIPTION
Feign 8.x will no longer support Dagger, nor interfaces annotated with `javax.inject.@Named`. Users must migrate from `javax.inject.@Named` to `feign.@Param` via Feign v7.1+ before attempting to update to Feign 8.0.

For example, the following uses `@Param` as opposed to `@Named` to annotate template parameters.

```java
interface GitHub {
  @RequestLine("GET /repos/{owner}/{repo}/contributors")
  List<Contributor> contributors(@Param("owner") String owner, @Param("repo") String repo);
}
```