### PR TITLE
Opens constructor for Gson and Jackson codecs which accepts type adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Version 7.2
-* Backports `Feign.Builder.build()` which exists in Feign 8.0.
+* Adds `Feign.Builder.build()`
+* Opens constructor for Gson and Jackson codecs which accepts type adapters
 
 ### Version 7.1
 * Introduces feign.@Param to annotate template parameters. Users must migrate from `javax.inject.@Named` to `feign.@Param` before updating to Feign 8.0.

--- a/gson/src/main/java/feign/gson/GsonDecoder.java
+++ b/gson/src/main/java/feign/gson/GsonDecoder.java
@@ -17,20 +17,25 @@ package feign.gson;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonIOException;
+import com.google.gson.TypeAdapter;
 import feign.Response;
 import feign.codec.Decoder;
-
 import java.io.IOException;
 import java.io.Reader;
 import java.lang.reflect.Type;
+import java.util.Collections;
 
 import static feign.Util.ensureClosed;
 
 public class GsonDecoder implements Decoder {
   private final Gson gson;
 
+  public GsonDecoder(Iterable<TypeAdapter<?>> adapters) {
+    this(GsonFactory.create(adapters));
+  }
+
   public GsonDecoder() {
-    this(new Gson());
+    this(Collections.<TypeAdapter<?>>emptyList());
   }
 
   public GsonDecoder(Gson gson) {

--- a/gson/src/main/java/feign/gson/GsonEncoder.java
+++ b/gson/src/main/java/feign/gson/GsonEncoder.java
@@ -16,14 +16,20 @@
 package feign.gson;
 
 import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
 import feign.RequestTemplate;
 import feign.codec.Encoder;
+import java.util.Collections;
 
 public class GsonEncoder implements Encoder {
   private final Gson gson;
 
+  public GsonEncoder(Iterable<TypeAdapter<?>> adapters) {
+    this(GsonFactory.create(adapters));
+  }
+
   public GsonEncoder() {
-    this(new Gson());
+    this(Collections.<TypeAdapter<?>>emptyList());
   }
 
   public GsonEncoder(Gson gson) {

--- a/gson/src/main/java/feign/gson/GsonFactory.java
+++ b/gson/src/main/java/feign/gson/GsonFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import static feign.Util.resolveLastTypeParameter;
+
+final class GsonFactory {
+
+  /**
+   * Registers type adapters by implicit type. Adds one to read numbers in a 
+   * {@code Map<String, Object>} as Integers.
+   */
+  static Gson create(Iterable<TypeAdapter<?>> adapters) {
+    GsonBuilder builder = new GsonBuilder().setPrettyPrinting();
+    builder.registerTypeAdapter(new TypeToken<Map<String, Object>>() {
+    }.getType(), new DoubleToIntMapTypeAdapter());
+    for (TypeAdapter<?> adapter : adapters) {
+      Type type = resolveLastTypeParameter(adapter.getClass(), TypeAdapter.class);
+      builder.registerTypeAdapter(type, adapter);
+    }
+    return builder.create();
+  }
+
+  private GsonFactory() {
+  }
+}

--- a/gson/src/main/java/feign/gson/GsonModule.java
+++ b/gson/src/main/java/feign/gson/GsonModule.java
@@ -16,19 +16,14 @@
 package feign.gson;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.TypeAdapter;
 import dagger.Provides;
 import feign.Feign;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
-
-import javax.inject.Singleton;
-import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Set;
-
-import static feign.Util.resolveLastTypeParameter;
+import javax.inject.Singleton;
 
 /**
  * <h3>Custom type adapters</h3>
@@ -78,12 +73,7 @@ public final class GsonModule {
   }
 
   @Provides @Singleton Gson gson(Set<TypeAdapter> adapters) {
-    GsonBuilder builder = new GsonBuilder().setPrettyPrinting();
-    for (TypeAdapter<?> adapter : adapters) {
-      Type type = resolveLastTypeParameter(adapter.getClass(), TypeAdapter.class);
-      builder.registerTypeAdapter(type, adapter);
-    }
-    return builder.create();
+    return GsonFactory.create((Iterable) adapters);
   }
 
   @Provides(type = Provides.Type.SET_VALUES) Set<TypeAdapter> noDefaultTypeAdapters() {

--- a/jackson/src/main/java/feign/jackson/JacksonDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonDecoder.java
@@ -16,6 +16,7 @@
 package feign.jackson;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
 import feign.Response;
@@ -24,12 +25,18 @@ import feign.codec.Decoder;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
+import java.util.Collections;
 
 public class JacksonDecoder implements Decoder {
   private final ObjectMapper mapper;
 
   public JacksonDecoder() {
-    this(new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false));
+    this(Collections.<Module>emptyList());
+  }
+
+  public JacksonDecoder(Iterable<Module> modules) {
+    this(new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .registerModules(modules));
   }
 
   public JacksonDecoder(ObjectMapper mapper) {

--- a/jackson/src/main/java/feign/jackson/JacksonEncoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonEncoder.java
@@ -17,26 +17,33 @@ package feign.jackson;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
 import feign.codec.Encoder;
+import java.util.Collections;
 
 public class JacksonEncoder implements Encoder {
   private final ObjectMapper mapper;
 
   public JacksonEncoder() {
+    this(Collections.<Module>emptyList());
+  }
+
+  public JacksonEncoder(Iterable<Module> modules) {
     this(new ObjectMapper()
         .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-        .configure(SerializationFeature.INDENT_OUTPUT, true));
+        .configure(SerializationFeature.INDENT_OUTPUT, true)
+        .registerModules(modules));
   }
 
   public JacksonEncoder(ObjectMapper mapper) {
     this.mapper = mapper;
   }
 
-  @Override public void encode(Object object, RequestTemplate template) throws EncodeException {
+  @Override public void encode(Object object, RequestTemplate template) {
     try {
       template.body(mapper.writeValueAsString(object));
     } catch (JsonProcessingException e) {

--- a/jackson/src/main/java/feign/jackson/JacksonModule.java
+++ b/jackson/src/main/java/feign/jackson/JacksonModule.java
@@ -15,19 +15,13 @@
  */
 package feign.jackson;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import dagger.Provides;
 import feign.Feign;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
-
-import javax.inject.Singleton;
 import java.util.Collections;
 import java.util.Set;
 
@@ -81,20 +75,12 @@ import java.util.Set;
  */
 @dagger.Module(injects = Feign.class, addsTo = Feign.Defaults.class)
 public final class JacksonModule {
-  @Provides Encoder encoder(ObjectMapper mapper) {
-    return new JacksonEncoder(mapper);
+  @Provides Encoder encoder(Set<Module> modules) {
+    return new JacksonEncoder(modules);
   }
 
-  @Provides Decoder decoder(ObjectMapper mapper) {
-    return new JacksonDecoder(mapper);
-  }
-
-  @Provides @Singleton ObjectMapper mapper(Set<Module> modules) {
-    return new ObjectMapper()
-        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-        .configure(SerializationFeature.INDENT_OUTPUT, true)
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        .registerModules(modules);
+  @Provides Decoder decoder(Set<Module> modules) {
+    return new JacksonDecoder(modules);
   }
 
   @Provides(type = Provides.Type.SET_VALUES) Set<Module> noDefaultModules() {


### PR DESCRIPTION
This simplifies construction when not using Dagger, and helps bridge
7.x to 8.x apis.