### PR TITLE
Adds EmptyTarget for interfaces who exclusively declare URI methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Removes support for parameters annotated with `javax.inject.@Named`. Use `feign.@Param` instead.
 * Makes body parameter type explicit.
 
+### Version 7.2
+* Adds EmptyTarget for interfaces who exclusively declare URI methods
+
 ### Version 7.1
 * Introduces feign.@Param to annotate template parameters. Users must migrate from `javax.inject.@Named` to `feign.@Param` before updating to Feign 8.0.
   * Supports custom expansion via `@Param(value = "name", expander = CustomExpander.class)`

--- a/core/src/main/java/feign/Target.java
+++ b/core/src/main/java/feign/Target.java
@@ -118,4 +118,64 @@ public interface Target<T> {
       return "HardCodedTarget(type=" + type.getSimpleName() + ", name=" + name + ", url=" + url + ")";
     }
   }
+
+  public static final class EmptyTarget<T> implements Target<T> {
+    private final Class<T> type;
+    private final String name;
+
+    EmptyTarget(Class<T> type, String name) {
+      this.type = checkNotNull(type, "type");
+      this.name = checkNotNull(emptyToNull(name), "name");
+    }
+    
+    public static <T> EmptyTarget<T> create(Class<T> type) {
+      return new EmptyTarget<T>(type, "empty:" + type.getSimpleName());
+    }
+
+    public static <T> EmptyTarget<T> create(Class<T> type, String name) {
+      return new EmptyTarget<T>(type, name);
+    }
+
+    @Override public Class<T> type() {
+      return type;
+    }
+
+    @Override public String name() {
+      return name;
+    }
+
+    @Override public String url() {
+      throw new UnsupportedOperationException("Empty targets don't have URLs");
+    }
+
+    @Override public Request apply(RequestTemplate input) {
+      if (input.url().indexOf("http") != 0) {
+        throw new UnsupportedOperationException("Request with non-absolute URL not supported with empty target");
+      }
+      return input.request();
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (obj instanceof EmptyTarget) {
+        EmptyTarget<?> other = (EmptyTarget) obj;
+        return type.equals(other.type)
+            && name.equals(other.name);
+      }
+      return false;
+    }
+
+    @Override public int hashCode() {
+      int result = 17;
+      result = 31 * result + type.hashCode();
+      result = 31 * result + name.hashCode();
+      return result;
+    }
+
+    @Override public String toString() {
+      if (name.equals("empty:" + type.getSimpleName())) {
+        return "EmptyTarget(type=" + type.getSimpleName() + ")";
+      }
+      return "EmptyTarget(type=" + type.getSimpleName() + ", name=" + name + ")";
+    }
+  }
 }

--- a/core/src/test/java/feign/EmptyTargetTest.java
+++ b/core/src/test/java/feign/EmptyTargetTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign;
+
+import feign.Target.EmptyTarget;
+import java.net.URI;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static feign.assertj.FeignAssertions.assertThat;
+
+public class EmptyTargetTest {
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  interface UriInterface {
+    @RequestLine("GET /") Response get(URI endpoint);
+  }
+
+  @Test public void whenNameNotSupplied() {
+    assertThat(EmptyTarget.create(UriInterface.class))
+        .isEqualTo(EmptyTarget.create(UriInterface.class, "empty:UriInterface"));
+  }
+
+  @Test public void toString_withoutName() {
+    assertThat(EmptyTarget.create(UriInterface.class).toString())
+        .isEqualTo("EmptyTarget(type=UriInterface)");
+  }
+
+  @Test public void toString_withName() {
+    assertThat(EmptyTarget.create(UriInterface.class, "manager-access").toString())
+        .isEqualTo("EmptyTarget(type=UriInterface, name=manager-access)");
+  }
+
+  @Test public void mustApplyToAbsoluteUrl() {
+    thrown.expect(UnsupportedOperationException.class);
+    thrown.expectMessage("Request with non-absolute URL not supported with empty target");
+
+    EmptyTarget.create(UriInterface.class).apply(new RequestTemplate().method("GET").append("/relative"));
+  }
+}


### PR DESCRIPTION
Supports cases when the base url isn't known until runtime.

Example use in denominator is discovery services such as Keystone.

Closes #98