### PR TITLE
Headers substitutions were not being expanded by the value name

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -205,7 +205,7 @@ public final class RequestTemplate implements Serializable {
       for (String value : valuesOrEmpty(headers, field)) {
         String resolved;
         if (value.indexOf('{') == 0) {
-          resolved = String.valueOf(unencoded.get(field));
+          resolved = expand(value, unencoded);
         } else {
           resolved = value;
         }

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -245,10 +245,10 @@ public class DefaultContractTest {
             HeaderParams.class.getDeclaredMethod("logout", String.class));
 
     assertThat(md.template())
-        .hasHeaders(entry("Auth-Token", asList("{Auth-Token}", "Foo")));
+        .hasHeaders(entry("Auth-Token", asList("{authToken}", "Foo")));
 
     assertThat(md.indexToName())
-        .containsExactly(entry(0, asList("Auth-Token")));
+        .containsExactly(entry(0, asList("authToken")));
   }
 
   @Test
@@ -343,8 +343,8 @@ public class DefaultContractTest {
   interface HeaderParams {
 
     @RequestLine("POST /")
-    @Headers({"Auth-Token: {Auth-Token}", "Auth-Token: Foo"})
-    void logout(@Param("Auth-Token") String token);
+    @Headers({"Auth-Token: {authToken}", "Auth-Token: Foo"})
+    void logout(@Param("authToken") String token);
   }
 
   interface CustomExpander {

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -127,6 +127,17 @@ public class RequestTemplateTest {
   }
 
   @Test
+  public void resolveTemplateWithHeaderSubstitutions() {
+    RequestTemplate template = new RequestTemplate().method("GET")
+        .header("Auth-Token", "{authToken}");
+
+    template.resolve(mapOf("authToken", "1234"));
+
+    assertThat(template)
+        .hasHeaders(entry("Auth-Token", asList("1234")));
+  }
+
+  @Test
   public void resolveTemplateWithMixedRequestLineParams() throws Exception {
     RequestTemplate template = new RequestTemplate().method("GET")//
         .append("/domains/{domainId}/records")//


### PR DESCRIPTION
Header params were using the header name instead of the value.

So if you had:

```
@Header({'Auth-Token', 'authToken'})
public String get(@Param('authToken') token);
```

It was looking up by 'Auth-Token' instead of 'authToken'  so it wouldn't substitute the value in 'token' above.

