### PR TITLE
Changed RibbonClient to pass Feign Request.Options to LBClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Removes support for parameters annotated with `javax.inject.@Named`. Use `feign.@Param` instead.
 * Makes body parameter type explicit.
 
+### Version 7.3
+* Adds Request.Options support to RibbonClient
+
 ### Version 7.2
 * Adds `Feign.Builder.build()`
 * Opens constructor for Gson and Jackson codecs which accepts type adapters

--- a/ribbon/src/main/java/feign/ribbon/RibbonClient.java
+++ b/ribbon/src/main/java/feign/ribbon/RibbonClient.java
@@ -2,6 +2,8 @@ package feign.ribbon;
 
 import com.netflix.client.ClientException;
 import com.netflix.client.ClientFactory;
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.ILoadBalancer;
 
@@ -45,7 +47,8 @@ public class RibbonClient implements Client {
       LBClient.RibbonRequest
           ribbonRequest =
           new LBClient.RibbonRequest(request, uriWithoutSchemeAndPort);
-      return lbClient(clientName).executeWithLoadBalancer(ribbonRequest).toResponse();
+      return lbClient(clientName).executeWithLoadBalancer(ribbonRequest,
+          new FeignOptionsClientConfig(options)).toResponse();
     } catch (ClientException e) {
       if (e.getCause() instanceof IOException) {
         throw IOException.class.cast(e.getCause());
@@ -59,4 +62,24 @@ public class RibbonClient implements Client {
     ILoadBalancer lb = ClientFactory.getNamedLoadBalancer(clientName);
     return new LBClient(delegate, lb, config);
   }
+  
+  static class FeignOptionsClientConfig extends DefaultClientConfigImpl {
+
+    public FeignOptionsClientConfig(Request.Options options) {
+      setProperty(CommonClientConfigKey.ConnectTimeout, options.connectTimeoutMillis());
+      setProperty(CommonClientConfigKey.ReadTimeout, options.readTimeoutMillis());
+    }
+
+    @Override
+    public void loadProperties(String clientName) {
+
+    }
+
+    @Override
+    public void loadDefaultValues() {
+
+    }
+
+  }
+  
 }

--- a/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
+++ b/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
@@ -15,24 +15,29 @@
  */
 package feign.ribbon;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.SocketPolicy;
-import com.squareup.okhttp.mockwebserver.rule.MockWebServerRule;
+import static com.netflix.config.ConfigurationManager.getConfigInstance;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.net.URL;
 
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
-import java.io.IOException;
-import java.net.URL;
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.IClientConfig;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.SocketPolicy;
+import com.squareup.okhttp.mockwebserver.rule.MockWebServerRule;
 
 import feign.Feign;
 import feign.Param;
+import feign.Request;
 import feign.RequestLine;
-
-import static com.netflix.config.ConfigurationManager.getConfigInstance;
-import static org.junit.Assert.assertEquals;
 
 public class RibbonClientTest {
 
@@ -134,6 +139,16 @@ public class RibbonClientTest {
     assertEquals(server1.getRequestCount(), 2);
     // TODO: verify ribbon stats match
     // assertEquals(target.lb().getLoadBalancerStats().getSingleServerStat())
+  }
+  
+  @Test
+  public void testFeignOptionsClientConfig() {
+    Request.Options options = new Request.Options(1111, 22222);
+    IClientConfig config = new RibbonClient.FeignOptionsClientConfig(options);
+    assertThat(config.get(CommonClientConfigKey.ConnectTimeout),
+        equalTo(options.connectTimeoutMillis()));
+    assertThat(config.get(CommonClientConfigKey.ReadTimeout), equalTo(options.readTimeoutMillis()));
+    assertEquals(2, config.getProperties().size());
   }
 
   private String client() {


### PR DESCRIPTION
With suggested changes and from a different branch.

Could this be merged back to the next 7.x release?