### PR TITLE
Reuse LBClient to avoid duplicate servo registrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ GitHub github = Feign.builder()
 
 Integration requires you to pass your ribbon client name as the host part of the url, for example `myAppProd`.
 ```java
-MyService api = Feign.builder().client(new RibbonClient()).target(MyService.class, "https://myAppProd");
+MyService api = Feign.builder().client(RibbonClient.DEFAULT).target(MyService.class, "https://myAppProd");
 
 ```
 

--- a/ribbon/src/main/java/feign/ribbon/RibbonClient.java
+++ b/ribbon/src/main/java/feign/ribbon/RibbonClient.java
@@ -1,30 +1,39 @@
 package feign.ribbon;
 
-import com.netflix.client.ClientException;
+import java.io.IOException;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import com.netflix.client.ClientFactory;
 import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.ILoadBalancer;
 
-import java.io.IOException;
-import java.net.URI;
-
 import feign.Client;
 import feign.Request;
 import feign.Response;
 
 /**
- * RibbonClient can be used in Fiegn builder to activate smart routing and resiliency capabilities
+ * RibbonClient can be used in Feign builder to activate smart routing and resiliency capabilities
  * provided by Ribbon. Ex.
+ * <p>
+ * 
  * <pre>
- * MyService api = Feign.builder.client(new RibbonClient()).target(MyService.class,
- * "http://myAppProd");
+ * MyService api = Feign.builder.client(RibbonClient.DEFAULT).target(MyService.class,
+ *     &quot;http://myAppProd&quot;);
  * </pre>
+ * 
+ * <p>
  * Where {@code myAppProd} is the ribbon client name and {@code myAppProd.ribbon.listOfServers}
  * configuration is set.
  */
 public class RibbonClient implements Client {
+
+  public static RibbonClient DEFAULT = new RibbonClient();
+  
+  private volatile Map<String, LBClient> lbClientCache = new LinkedHashMap<String, LBClient>();
 
   private final Client delegate;
 
@@ -41,15 +50,13 @@ public class RibbonClient implements Client {
     try {
       URI asUri = URI.create(request.url());
       String clientName = asUri.getHost();
-      URI
-          uriWithoutSchemeAndPort =
-          URI.create(request.url().replace(asUri.getScheme() + "://" + asUri.getHost(), ""));
-      LBClient.RibbonRequest
-          ribbonRequest =
-          new LBClient.RibbonRequest(request, uriWithoutSchemeAndPort);
-      return lbClient(clientName).executeWithLoadBalancer(ribbonRequest,
-          new FeignOptionsClientConfig(options)).toResponse();
-    } catch (ClientException e) {
+      URI uriWithoutHost = URI.create(request.url().replace(asUri.getHost(), ""));
+      LBClient.RibbonRequest ribbonRequest =
+          new LBClient.RibbonRequest(request, uriWithoutHost, delegate);
+      return getOrCreateLBClient(clientName).executeWithLoadBalancer(ribbonRequest,
+          new FeignOptionsClientConfig(options))
+          .toResponse();
+    } catch (Exception e) {
       if (e.getCause() instanceof IOException) {
         throw IOException.class.cast(e.getCause());
       }
@@ -57,12 +64,33 @@ public class RibbonClient implements Client {
     }
   }
 
-  private LBClient lbClient(String clientName) {
-    IClientConfig config = ClientFactory.getNamedConfig(clientName);
-    ILoadBalancer lb = ClientFactory.getNamedLoadBalancer(clientName);
-    return new LBClient(delegate, lb, config);
+  /**
+   * Returns a cached version of the {@link LBClient} if it exists otherwise a new {@link LBClient}
+   * is created and added to the cache.
+   * <p>
+   * Ribbon does not expect multiple LBClient instances for the same client. This introduces a cache
+   * to avoid redundantly creating them.
+   * 
+   * @param clientName - The clientName that the {@link LBClient} will be cache against
+   * @return
+   */
+  private LBClient getOrCreateLBClient(String clientName) {
+    if (lbClientCache.containsKey(clientName)) {
+      return lbClientCache.get(clientName);
+    } else {
+      synchronized (this) {
+        LBClient lbClient = lbClientCache.get(clientName);
+        if (lbClient == null) {
+          IClientConfig config = ClientFactory.getNamedConfig(clientName);
+          ILoadBalancer lb = ClientFactory.getNamedLoadBalancer(clientName);
+          lbClient = new LBClient(lb, config);
+          lbClientCache.put(clientName, lbClient);
+        }
+        return lbClient;
+      }
+    }
   }
-  
+
   static class FeignOptionsClientConfig extends DefaultClientConfigImpl {
 
     public FeignOptionsClientConfig(Request.Options options) {


### PR DESCRIPTION
issue #182 found that the default configuration of servo does static registration for each LBClient instance. This creates problems at runtime. The solution proposed here is to avoid duplicating LBClient instances by caching them.