### PR TITLE
Fix NPE when building a client with a query param with no values

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -504,7 +504,7 @@ public final class RequestTemplate implements Serializable {
   }
 
   private boolean allValuesAreNull(Collection<String> values) {
-    if (values.isEmpty()) {
+    if (values == null || values.isEmpty()) {
       return true;
     }
     for (String val : values) {


### PR DESCRIPTION
Using feign-core 7.1.0, when creating a feign client with a query param with no values, the builder throws a NPE. I didn't want to include Apache CollectionsUtils so I just added a `null` check. Thanks for the great library btw, hope this PR is OK!

TestApi.java: 
```java
public interface TestApi
{
    @RequestLine("POST /api/{parameter}?in_error")
    void updateInError(@Named("parameter")String parameter);
}
```

Builder : 
```java
Feign.builder()
         .decoder(new GsonDecoder())
         .encoder(new GsonEncoder())
         .logLevel(Level.FULL)
         .target(TestApi.class, "http://localhost:8888");
```

throws this stackstrace : 
```
java.lang.NullPointerException: null
	at feign.RequestTemplate.allValuesAreNull(RequestTemplate.java:494) ~[feign-core-7.1.0.jar:7.1.0]
	at feign.RequestTemplate.pullAnyQueriesOutOfUrl(RequestTemplate.java:476) ~[feign-core-7.1.0.jar:7.1.0]
	at feign.RequestTemplate.append(RequestTemplate.java:207) ~[feign-core-7.1.0.jar:7.1.0]
	at feign.Contract$Default.processAnnotationOnMethod(Contract.java:137) ~[feign-core-7.1.0.jar:7.1.0]
	at feign.Contract$BaseContract.parseAndValidatateMetadata(Contract.java:62) ~[feign-core-7.1.0.jar:7.1.0]
	at feign.Contract$BaseContract.parseAndValidatateMetadata(Contract.java:48) ~[feign-core-7.1.0.jar:7.1.0]
	at feign.ReflectiveFeign$ParseHandlersByName.apply(ReflectiveFeign.java:143) ~[feign-core-7.1.0.jar:7.1.0]
	at feign.ReflectiveFeign.newInstance(ReflectiveFeign.java:58) ~[feign-core-7.1.0.jar:7.1.0]
	at feign.Feign$Builder.target(Feign.java:265) ~[feign-core-7.1.0.jar:7.1.0]
	at feign.Feign$Builder.target(Feign.java:261) ~[feign-core-7.1.0.jar:7.1.0]
```