### PR TITLE
Accepts codec exceptions without a message

### DIFF
--- a/core/src/main/java/feign/FeignException.java
+++ b/core/src/main/java/feign/FeignException.java
@@ -36,7 +36,8 @@ public class FeignException extends RuntimeException {
 
   static FeignException errorReading(Request request, Response ignored, IOException cause) {
     return new FeignException(
-        format("%s %s %s", cause.getMessage(), request.method(), request.url()), cause);
+        format("%s reading %s %s", cause.getMessage(), request.method(), request.url()),
+        cause);
   }
 
   public static FeignException errorStatus(String methodKey, Response response) {
@@ -53,7 +54,7 @@ public class FeignException extends RuntimeException {
 
   static FeignException errorExecuting(Request request, IOException cause) {
     return new RetryableException(
-        format("error %s executing %s %s", cause.getMessage(), request.method(),
-               request.url()), cause, null);
+        format("%s executing %s %s", cause.getMessage(), request.method(), request.url()), cause,
+        null);
   }
 }

--- a/core/src/main/java/feign/codec/DecodeException.java
+++ b/core/src/main/java/feign/codec/DecodeException.java
@@ -36,10 +36,10 @@ public class DecodeException extends FeignException {
   }
 
   /**
-   * @param message the reason for the failure.
+   * @param message possibly null reason for the failure.
    * @param cause   the cause of the error.
    */
   public DecodeException(String message, Throwable cause) {
-    super(checkNotNull(message, "message"), checkNotNull(cause, "cause"));
+    super(message, checkNotNull(cause, "cause"));
   }
 }

--- a/core/src/main/java/feign/codec/EncodeException.java
+++ b/core/src/main/java/feign/codec/EncodeException.java
@@ -36,10 +36,10 @@ public class EncodeException extends FeignException {
   }
 
   /**
-   * @param message the reason for the failure.
+   * @param message possibly null reason for the failure.
    * @param cause   the cause of the error.
    */
   public EncodeException(String message, Throwable cause) {
-    super(checkNotNull(message, "message"), checkNotNull(cause, "cause"));
+    super(message, checkNotNull(cause, "cause"));
   }
 }


### PR DESCRIPTION
While encoding or decoding, an exception without a message can occur.
Before this change, a NPE would return as the codec exceptions null
checked the message from the cause.