### PR TITLE
Allows `@Headers` to be applied to a type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
+### Version 8.1
+* Allows `@Headers` to be applied to a type
+
 ### Version 8.0
 * Removes Dagger 1.x Dependency
 * Removes support for parameters annotated with `javax.inject.@Named`. Use `feign.@Param` instead.
 * Makes body parameter type explicit.
+
+### Version 7.4
+* Allows `@Headers` to be applied to a type
 
 ### Version 7.3
 * Adds Request.Options support to RibbonClient

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -131,6 +131,21 @@ public interface Contract {
   class Default extends BaseContract {
 
     @Override
+    public MethodMetadata parseAndValidatateMetadata(Method method) {
+      MethodMetadata data = super.parseAndValidatateMetadata(method);
+      if (method.getDeclaringClass().isAnnotationPresent(Headers.class)) {
+        String[] headersOnType = method.getDeclaringClass().getAnnotation(Headers.class).value();
+        checkState(headersOnType.length > 0, "Headers annotation was empty on type %s.",
+                   method.getDeclaringClass().getName());
+        Map<String, Collection<String>> headers = toMap(headersOnType);
+        headers.putAll(data.template().headers());
+        data.template().headers(null); // to clear
+        data.template().headers(headers);
+      }
+      return data;
+    }
+
+    @Override
     protected void processAnnotationOnMethod(MethodMetadata data, Annotation methodAnnotation,
                                              Method method) {
       Class<? extends Annotation> annotationType = methodAnnotation.annotationType();
@@ -161,21 +176,10 @@ public interface Contract {
           data.template().bodyTemplate(body);
         }
       } else if (annotationType == Headers.class) {
-        String[] headersToParse = Headers.class.cast(methodAnnotation).value();
-        checkState(headersToParse.length > 0, "Headers annotation was empty on method %s.",
+        String[] headersOnMethod = Headers.class.cast(methodAnnotation).value();
+        checkState(headersOnMethod.length > 0, "Headers annotation was empty on method %s.",
                    method.getName());
-        Map<String, Collection<String>>
-            headers =
-            new LinkedHashMap<String, Collection<String>>(headersToParse.length);
-        for (String header : headersToParse) {
-          int colon = header.indexOf(':');
-          String name = header.substring(0, colon);
-          if (!headers.containsKey(name)) {
-            headers.put(name, new ArrayList<String>(1));
-          }
-          headers.get(name).add(header.substring(colon + 2));
-        }
-        data.template().headers(headers);
+        data.template().headers(toMap(headersOnMethod));
       }
     }
 
@@ -208,7 +212,7 @@ public interface Contract {
       return isHttpAnnotation;
     }
 
-    private <K, V> boolean searchMapValues(Map<K, Collection<V>> map, V search) {
+    private static <K, V> boolean searchMapValues(Map<K, Collection<V>> map, V search) {
       Collection<Collection<V>> values = map.values();
       if (values == null) {
         return false;
@@ -221,6 +225,21 @@ public interface Contract {
       }
 
       return false;
+    }
+
+    private static Map<String, Collection<String>> toMap(String[] input) {
+      Map<String, Collection<String>>
+          result =
+          new LinkedHashMap<String, Collection<String>>(input.length);
+      for (String header : input) {
+        int colon = header.indexOf(':');
+        String name = header.substring(0, colon);
+        if (!result.containsKey(name)) {
+          result.put(name, new ArrayList<String>(1));
+        }
+        result.get(name).add(header.substring(colon + 2));
+      }
+      return result;
     }
   }
 }

--- a/core/src/main/java/feign/Headers.java
+++ b/core/src/main/java/feign/Headers.java
@@ -4,11 +4,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Expands headers supplied in the {@code value}.  Variables are permitted as values. <br>
  * <pre>
+ * &#64;Headers("Content-Type: application/xml")
+ * interface SoapApi {
+ * ...   
  * &#64;RequestLine("GET /")
  * &#64;Headers("Cache-Control: max-age=640000")
  * ...
@@ -37,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * ...
  * </pre>
  */
-@Target(METHOD)
+@Target({METHOD, TYPE})
 @Retention(RUNTIME)
 public @interface Headers {
 

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -377,8 +377,7 @@ public final class RequestTemplate implements Serializable {
    * JAXRS 2.0</b><br> <br> Like {@code Invocation.Builder.headers(MultivaluedMap)}, except the
    * values can be templatized. <br> ex. <br>
    * <pre>
-   * template.headers(ImmutableMultimap.of(&quot;X-Application-Version&quot;,
-   * &quot;{version}&quot;));
+   * template.headers(mapOf(&quot;X-Application-Version&quot;, asList(&quot;{version}&quot;)));
    * </pre>
    *
    * @param headers if null, remove all headers. else value to replace all headers with.

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -163,10 +163,23 @@ public class DefaultContractTest {
   }
 
   @Test
-  public void producesAddsContentTypeHeader() throws Exception {
+  public void headersOnMethodAddsContentTypeHeader() throws Exception {
     MethodMetadata
         md =
         contract.parseAndValidatateMetadata(BodyWithoutParameters.class.getDeclaredMethod("post"));
+
+    assertThat(md.template())
+        .hasHeaders(
+            entry("Content-Type", asList("application/xml")),
+            entry("Content-Length", asList(String.valueOf(md.template().body().length)))
+        );
+  }
+
+  @Test
+  public void headersOnTypeAddsContentTypeHeader() throws Exception {
+    MethodMetadata
+        md =
+        contract.parseAndValidatateMetadata(HeadersOnType.class.getDeclaredMethod("post"));
 
     assertThat(md.template())
         .hasHeaders(
@@ -338,6 +351,14 @@ public class DefaultContractTest {
 
     @RequestLine("POST /")
     @Headers("Content-Type: application/xml")
+    @Body("<v01:getAccountsListOfUser/>")
+    Response post();
+  }
+
+  @Headers("Content-Type: application/xml")
+  interface HeadersOnType {
+
+    @RequestLine("POST /")
     @Body("<v01:getAccountsListOfUser/>")
     Response post();
   }


### PR DESCRIPTION
This supports interface-level defaults, such as Content-Type.

closes #184