### PR TITLE
Move to 2.2.8 which has the release.travisci flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'nebula.netflixoss' version '2.2.7'
+    id 'nebula.netflixoss' version '2.2.8'
 }
 
 ext {


### PR DESCRIPTION
which disables certain checks on tag releases. Another attempt at getting travis release working.