### PR TITLE
Enforces source compatibility with animal-sniffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 8.2
+* Enforces source compatibility with animal-sniffer
+
 ### Version 8.1
 * Allows `@Headers` to be applied to a type
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,10 @@
+buildscript {
+    repositories { jcenter() }
+    dependencies {
+        classpath 'be.insaneprogramming.gradle:animalsniffer-gradle-plugin:1.4.0'
+    }
+}
+
 plugins {
     id 'nebula.netflixoss' version '2.2.9'
 }
@@ -13,4 +20,9 @@ subprojects {
         jcenter()
     }
     group = "com.netflix.${githubProjectName}" // TEMPLATE: Set to organization of project
+    apply plugin: 'be.insaneprogramming.gradle.animalsniffer'
+
+    animalsniffer { // Don't use apis that may not be available on Android
+        signature = "org.codehaus.mojo.signature:java16:+@signature"
+    }
 }


### PR DESCRIPTION
Before, finding source compatibility issues relied on building with an
old JDK. This uses animal-sniffer to enforce java language level 6.