### PR TITLE
Enable caching for gradle dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ jdk:
 - oraclejdk7
 install: ./installViaTravis.sh
 script: ./buildViaTravis.sh
+cache:
+  directories:
+  - $HOME/.gradle/caches/
 env:
   global:
   - secure: Ps7+oTi5FfjwJ7tQ8G51wk30ZHqB1P4ZNXsGisn+r/8IJRxPs6VNIF/dPSkWLERs1tBvMG2sRz9nxaIwxXJwHXOkoBL/SXZHzOYwKTlsNcu72B6czxepIb0OAGWKAv6aCk9vAJkRzGX2Ogy+Hnn8AuQlPAPOplRjZm1AXj6smGM=


### PR DESCRIPTION
If I read their docs correctly this should cache the dependencies.