### PR TITLE
Correct time decoding in RetryAfterDecoder

### DIFF
--- a/core/src/main/java/feign/codec/ErrorDecoder.java
+++ b/core/src/main/java/feign/codec/ErrorDecoder.java
@@ -113,7 +113,7 @@ public interface ErrorDecoder {
       this.rfc822Format = checkNotNull(rfc822Format, "rfc822Format");
     }
 
-    protected long currentTimeNanos() {
+    protected long currentTimeMillis() {
       return System.currentTimeMillis();
     }
 
@@ -128,9 +128,8 @@ public interface ErrorDecoder {
         return null;
       }
       if (retryAfter.matches("^[0-9]+$")) {
-        long currentTimeMillis = NANOSECONDS.toMillis(currentTimeNanos());
         long deltaMillis = SECONDS.toMillis(Long.parseLong(retryAfter));
-        return new Date(currentTimeMillis + deltaMillis);
+        return new Date(currentTimeMillis() + deltaMillis);
       }
       synchronized (rfc822Format) {
         try {

--- a/core/src/test/java/feign/codec/RetryAfterDecoderTest.java
+++ b/core/src/test/java/feign/codec/RetryAfterDecoderTest.java
@@ -29,9 +29,9 @@ import static org.junit.Assert.assertFalse;
 public class RetryAfterDecoderTest {
 
   private RetryAfterDecoder decoder = new RetryAfterDecoder(RFC822_FORMAT) {
-    protected long currentTimeNanos() {
+    protected long currentTimeMillis() {
       try {
-        return MILLISECONDS.toNanos(RFC822_FORMAT.parse("Sat, 1 Jan 2000 00:00:00 GMT").getTime());
+        return RFC822_FORMAT.parse("Sat, 1 Jan 2000 00:00:00 GMT").getTime();
       } catch (ParseException e) {
         throw new RuntimeException(e);
       }


### PR DESCRIPTION
currentTimeNanos was not returning nanos.