### PR TITLE
Corrects encoding of space in URL parameter

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -188,7 +188,7 @@ public final class RequestTemplate implements Serializable {
     for (Entry<String, ?> entry : unencoded.entrySet()) {
       encoded.put(entry.getKey(), urlEncode(String.valueOf(entry.getValue())));
     }
-    String resolvedUrl = expand(url.toString(), encoded).replace("%2F", "/");
+    String resolvedUrl = expand(url.toString(), encoded).replace("%2F", "/").replace("+", "%20");
     url = new StringBuilder(resolvedUrl);
 
     Map<String, Collection<String>>

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -230,4 +230,15 @@ public class RequestTemplateTest {
         .hasUrl("/domains/1001/records")
         .hasQueries();
   }
+
+  @Test
+  public void spaceEncodingInUrlParam() {
+    RequestTemplate template = new RequestTemplate().method("GET")//
+        .append("/api/{value1}?key={value2}");
+
+    template = template.resolve(mapOf("value1", "ABC 123", "value2", "XYZ 123"));
+
+    assertThat(template.request().url())
+        .isEqualTo("/api/ABC%20123?key=XYZ+123");
+  }
 }


### PR DESCRIPTION
According to rfc2396, space in url should be encoded as "%20" instead
of "+".

Closes #225