### PR TITLE
Allow for customization of statusCode interpretation

### DIFF
--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -84,6 +84,7 @@ public abstract class Feign {
     private InvocationHandlerFactory
         invocationHandlerFactory =
         new InvocationHandlerFactory.Default();
+    private StatusInterpreter statusInterpreter = new StatusInterpreter.Default();
 
     public Builder logLevel(Logger.Level logLevel) {
       this.logLevel = logLevel;
@@ -157,6 +158,18 @@ public abstract class Feign {
       this.invocationHandlerFactory = invocationHandlerFactory;
       return this;
     }
+    /**
+     * Allows you to override the {@link StatusInterpreter}.
+     * The default interpreter treats any non-200 class status code
+     * as a reason to raise exception. Use this to provide alternative
+     * logic (like allowing 404 to gracefully return null).
+     * 
+     * @see StatusInterpreter.Include404
+     */
+    public Builder statusInterpreter(StatusInterpreter statusInterpreter) {
+      this.statusInterpreter = statusInterpreter;
+      return this;
+    }
 
     public <T> T target(Class<T> apiType, String url) {
       return target(new HardCodedTarget<T>(apiType, url));
@@ -169,7 +182,7 @@ public abstract class Feign {
     public Feign build() {
       SynchronousMethodHandler.Factory synchronousMethodHandlerFactory =
           new SynchronousMethodHandler.Factory(client, retryer, requestInterceptors, logger,
-                                               logLevel);
+                                               logLevel, statusInterpreter);
       ParseHandlersByName
           handlersByName =
           new ParseHandlersByName(contract, options, encoder, decoder,

--- a/core/src/main/java/feign/StatusInterpreter.java
+++ b/core/src/main/java/feign/StatusInterpreter.java
@@ -1,0 +1,53 @@
+/**
+ * 
+ */
+package feign;
+
+import feign.codec.ErrorDecoder;
+
+/**
+ * Interface responsible for interpreting HTTP status codes from Responses.
+ * 
+ * @author Nicholas Blair
+ */
+public interface StatusInterpreter {
+
+  /**
+   * Implementations should return true if the status code suggests a Response is interpretable.
+   * When false is returned, it means the statusCode should result in a Exception being thrown (that
+   * the {@link ErrorDecoder} will handle).
+   * 
+   * @see ErrorDecoder
+   * @param statusCode
+   * @return true if the response is interpretable.
+   */
+  public boolean isInterpretableResponse(int statusCode);
+  
+  /**
+   * Default {@link StatusInterpreter}.
+   */
+  public static class Default implements StatusInterpreter {
+    /**
+     * {@inheritDoc}
+     * Returns true for all 200 classs= statusCodes.
+     */
+    @Override
+    public boolean isInterpretableResponse(int statusCode) {
+      return statusCode >= 200 && statusCode < 300;
+    }
+  }
+  /**
+   * Optional {@link StatusInterpreter} that behaves like {@link Default} 
+   * but additionally handles 404.
+   */
+  public static class Include404 extends Default implements StatusInterpreter {
+    /**
+     * {@inheritDoc}
+     * Returns true for {@link Default#isInterpretableResponse(int)} OR 404.
+     */
+    @Override
+    public boolean isInterpretableResponse(int statusCode) {
+      return super.isInterpretableResponse(statusCode) || statusCode == 404;
+    }
+  }
+}

--- a/core/src/test/java/feign/StatusInterpreterTest.java
+++ b/core/src/test/java/feign/StatusInterpreterTest.java
@@ -1,0 +1,49 @@
+/**
+ * 
+ */
+package feign;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link StatusInterpreter}.
+ */
+public class StatusInterpreterTest {
+
+  @Test
+  public void default_isInterpretable_200_class() {
+    isTrue(new StatusInterpreter.Default(), 200, 201, 204, 210);  
+  }
+  @Test
+  public void default_isInterpretable_300_class() {
+    isFalse(new StatusInterpreter.Default(), 301, 302);
+  }
+
+  @Test
+  public void default_isInterpretable_400_class() {
+    isFalse(new StatusInterpreter.Default(), 400, 401, 403, 404);
+  }
+  @Test
+  public void default_isInterpretable_500_class() {
+    isFalse(new StatusInterpreter.Default(), 400, 401, 403, 500);
+  }
+  
+  @Test
+  public void include404_isInterpretable_400_class() {
+    isFalse(new StatusInterpreter.Include404(), 400, 401, 403);
+    isTrue(new StatusInterpreter.Include404(), 404);
+  }
+  protected void isFalse(StatusInterpreter interpreter, Integer... statuses) {
+    for(Integer status: statuses) {
+      assertFalse(interpreter.isInterpretableResponse(status));
+    }
+  }
+  protected void isTrue(StatusInterpreter interpreter, Integer... statuses) {
+    for(Integer status: statuses) {
+      assertTrue(interpreter.isInterpretableResponse(status));
+    }
+  }
+}


### PR DESCRIPTION
We just started looking at Feign for implementing client libraries for some REST APIs.

We wanted to setup an interface like so:

```java
public interface FooAPI {

  /**
   * Retrieve the {@link Foo} that has a matching value for {@link Foo#getId()}.
   * 
   * @param id the id of the {@link Foo}
   * @return the corresponding {@link Foo}, or null if not found
   */
 @RequestLine("GET /api/v1/foo/{id}")
 Foo retrieveById(@Param("id") String id);
```

The REST API's contract states that `/api/v1/foo/{id}` will return a 404 if no resource exists with that id.

In the current 8.3 release of Feign, a return code of 404 is treated as something that should raise an Exception. Our method signature would have to look like this instead:

```java
public interface FooAPI {

  /**
   * Retrieve the {@link Foo} that has a matching value for {@link Foo#getId()}.
   * 
   * @param id the id of the {@link Foo}
   * @return the corresponding {@link Foo}
   * @throws FooNotFoundException if no {@link Foo} exists with the id
   */
 @RequestLine("GET /api/v1/foo/{id}")
 Foo retrieveById(@Param("id") String id) throws FooNotFoundException;
```

We'd prefer not to have to create an exception for this scenario.
This pull request adds a new interface encapsulating logic currently at line 106 of:

https://github.com/Netflix/feign/blob/8.x/core/src/main/java/feign/SynchronousMethodHandler.java

Previously, inline
logic in SynchronousMethodHandler only treated 200 class status codes as
something to parse; everything else, including 404, as reason to throw exception (ErrorDecoder then takes over).

This change allows callers to inject StatusInterpreter.Include404 if they desire a contract that can return null for 404 like the one presented at the top rather than raising an Exception. The interface allows for further customization if desired.

The default behavior is unchanged.