### PR TITLE
Correct retry handling for repeatable requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Version 8.4
+* Correct Retryer bug that prevented it from retrying requests after the first 5 retry attempts.
+  * **Note:** If you have a custom `feign.Retryer` implementation you now must now implement `public Retryer clone()`.
+  It is suggested that you simply return a new instance of your Retryer class.
+
 ### Version 8.3
 * Adds client implementation for Apache Http Client 
 

--- a/core/src/main/java/feign/Retryer.java
+++ b/core/src/main/java/feign/Retryer.java
@@ -18,15 +18,17 @@ package feign;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
- * Created for each invocation to {@link Client#execute(Request, feign.Request.Options)}.
+ * Cloned for each invocation to {@link Client#execute(Request, feign.Request.Options)}.
  * Implementations may keep state to determine if retry operations should continue or not.
  */
-public interface Retryer {
+public interface Retryer extends Cloneable {
 
   /**
    * if retry is permitted, return (possibly after sleeping). Otherwise propagate the exception.
    */
   void continueOrPropagate(RetryableException e);
+
+  Retryer clone();
 
   public static class Default implements Retryer {
 
@@ -35,6 +37,7 @@ public interface Retryer {
     private final long maxPeriod;
     int attempt;
     long sleptForMillis;
+
     public Default() {
       this(100, SECONDS.toMillis(1), 5);
     }
@@ -86,6 +89,11 @@ public interface Retryer {
     long nextMaxInterval() {
       long interval = (long) (period * Math.pow(1.5, attempt - 1));
       return interval > maxPeriod ? maxPeriod : interval;
+    }
+
+    @Override
+    public Retryer clone() {
+      return new Default(period, maxPeriod, maxAttempts);
     }
   }
 }

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -65,7 +65,7 @@ final class SynchronousMethodHandler implements MethodHandler {
   @Override
   public Object invoke(Object[] argv) throws Throwable {
     RequestTemplate template = buildTemplateFromArgs.create(argv);
-    Retryer retryer = this.retryer;
+    Retryer retryer = this.retryer.clone();
     while (true) {
       try {
         return executeAndDecode(template);

--- a/core/src/test/java/feign/LoggerTest.java
+++ b/core/src/test/java/feign/LoggerTest.java
@@ -214,6 +214,9 @@ public class LoggerTest {
             public void continueOrPropagate(RetryableException e) {
               throw e;
             }
+            @Override public Retryer clone() {
+                return this;
+            }
           })
           .target(SendsStuff.class, "http://robofu.abc");
 
@@ -263,6 +266,11 @@ public class LoggerTest {
                 return;
               }
               throw e;
+            }
+
+            @Override
+            public Retryer clone() {
+                return this;
             }
           })
           .target(SendsStuff.class, "http://robofu.abc");


### PR DESCRIPTION
Previously, the Retryer instance provided to the Builder was simply reused, but the instance keeps per-request state, causing repeatable requests to stop being retried. Fixes #236