### PR TITLE
Fix an issue with trailing slashes in @Path annotations on classes

### DIFF
--- a/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
+++ b/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
@@ -54,6 +54,10 @@ public final class JAXRSContract extends Contract.BaseContract {
       if (!pathValue.startsWith("/")) {
         pathValue = "/" + pathValue;
       }
+      if (pathValue.endsWith("/")) {
+          // Strip off any trailing slashes, since the template has already had slashes appropriately added
+          pathValue = pathValue.substring(0, pathValue.length()-1);
+      }
       md.template().insert(0, pathValue);
     }
     return md;

--- a/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
+++ b/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
@@ -374,6 +374,22 @@ public class JAXRSContractTest {
 
   }
 
+  @Test
+  public void classWithRootPathParsesCorrectly() throws Exception {
+      assertThat(
+              contract.parseAndValidatateMetadata(ClassRootPath.class.getDeclaredMethod("get"))
+                  .template())
+              .hasUrl("/specific");
+  }
+
+  @Test
+  public void classPathWithTrailingSlashParsesCorrectly() throws Exception {
+      assertThat(
+              contract.parseAndValidatateMetadata(ClassPathWithTrailingSlash.class.getDeclaredMethod("get"))
+                  .template())
+              .hasUrl("/base/specific");
+  }
+
   interface Methods {
 
     @POST
@@ -548,5 +564,19 @@ public class JAXRSContractTest {
     @GET
     @Path("/specific")
     Response get();
+  }
+
+  @Path("/")
+  interface ClassRootPath {
+      @GET
+      @Path("/specific")
+      Response get();
+  }
+
+  @Path("/base/")
+  interface ClassPathWithTrailingSlash {
+      @GET
+      @Path("/specific")
+      Response get();
   }
 }


### PR DESCRIPTION
This fixes what appears to be a regression from 6.x to 7.x/8.x. If I have this:
```
@Path("/")
class MyClass {
    @Path("base")
    void get();
}
```
Then feign will try to send "//base", instead of just "/base". This also fixes the case where I have:
```
@Path("/api/")
class MyClass {
    @Path("base")
    void get();
}
```
which would try to hit /api//base instead of /api/base.