### PR TITLE
Strip regex allowed by the jaxrs spec.

### DIFF
--- a/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
+++ b/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
@@ -77,6 +77,11 @@ public final class JAXRSContract extends Contract.BaseContract {
       if (!methodAnnotationValue.startsWith("/") && !data.template().toString().endsWith("/")) {
         methodAnnotationValue = "/" + methodAnnotationValue;
       }
+      int regexIndex = methodAnnotationValue.indexOf(":");
+      if (methodAnnotationValue.indexOf("{") != -1 && regexIndex != -1) {
+          // The method annotation includes a regex, which should be stripped to get the true path parameter name.
+          methodAnnotationValue = methodAnnotationValue.substring(0, regexIndex) + "}";
+      }
       data.template().append(methodAnnotationValue);
     } else if (annotationType == Produces.class) {
       String[] serverProduces = ((Produces) methodAnnotation).value();

--- a/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
+++ b/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
@@ -249,6 +249,13 @@ public class JAXRSContractTest {
   }
 
   @Test
+  public void regexPathOnMethod() throws Exception {
+      assertThat(contract.parseAndValidatateMetadata(
+          PathOnType.class.getDeclaredMethod("pathParamWithRegex", String.class)).template())
+      .hasUrl("/base/regex/{param}");
+  }
+
+  @Test
   public void withPathAndURIParams() throws Exception {
     MethodMetadata md = contract.parseAndValidatateMetadata(
         WithURIParam.class.getDeclaredMethod("uriParam", String.class, URI.class, String.class));
@@ -485,6 +492,10 @@ public class JAXRSContractTest {
     @GET
     @Path("/{param}")
     Response emptyPathParam(@PathParam("") String empty);
+
+    @GET
+    @Path("regex/{param:.+}")
+    Response pathParamWithRegex(@PathParam("param") String path);
   }
 
   interface WithURIParam {


### PR DESCRIPTION
Jax-rs allows for a regex to appear at the end of an @Path annotation (https://jersey.java.net/documentation/latest/jaxrs-resources.html#d0e1961). This lets the JaxRsContract deal with that appropriately