### PR TITLE
Fix regex support when there are multiple @Path regexes

### DIFF
--- a/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
+++ b/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
@@ -81,11 +81,9 @@ public final class JAXRSContract extends Contract.BaseContract {
       if (!methodAnnotationValue.startsWith("/") && !data.template().toString().endsWith("/")) {
         methodAnnotationValue = "/" + methodAnnotationValue;
       }
-      int regexIndex = methodAnnotationValue.indexOf(":");
-      if (methodAnnotationValue.indexOf("{") != -1 && regexIndex != -1) {
-          // The method annotation includes a regex, which should be stripped to get the true path parameter name.
-          methodAnnotationValue = methodAnnotationValue.substring(0, regexIndex) + "}";
-      }
+      // jax-rs allows whitespace around the param name, as well as an optional regex. The contract should
+      // strip these out appropriately.
+      methodAnnotationValue = methodAnnotationValue.replaceAll("\\{\\s*(.+?)\\s*(:.+?)?\\}", "\\{$1\\}");
       data.template().append(methodAnnotationValue);
     } else if (annotationType == Produces.class) {
       String[] serverProduces = ((Produces) methodAnnotation).value();

--- a/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
+++ b/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
@@ -249,10 +249,21 @@ public class JAXRSContractTest {
   }
 
   @Test
+  public void pathParamWithSpaces() throws Exception {
+      assertThat(contract.parseAndValidatateMetadata(
+              PathOnType.class.getDeclaredMethod("pathParamWithSpaces", String.class)).template())
+          .hasUrl("/base/{param}");
+  }
+
+  @Test
   public void regexPathOnMethod() throws Exception {
       assertThat(contract.parseAndValidatateMetadata(
           PathOnType.class.getDeclaredMethod("pathParamWithRegex", String.class)).template())
       .hasUrl("/base/regex/{param}");
+
+      assertThat(contract.parseAndValidatateMetadata(
+              PathOnType.class.getDeclaredMethod("pathParamWithMultipleRegex", String.class, String.class)).template())
+      .hasUrl("/base/regex/{param1}/{param2}");
   }
 
   @Test
@@ -510,8 +521,16 @@ public class JAXRSContractTest {
     Response emptyPathParam(@PathParam("") String empty);
 
     @GET
+    @Path("/{   param   }")
+    Response pathParamWithSpaces(@PathParam("param") String path);
+
+    @GET
     @Path("regex/{param:.+}")
     Response pathParamWithRegex(@PathParam("param") String path);
+
+    @GET
+    @Path("regex/{param1:[0-9]*}/{  param2 : .+}")
+    Response pathParamWithMultipleRegex(@PathParam("param1") String param1, @PathParam("param2") String param2);
   }
 
   interface WithURIParam {


### PR DESCRIPTION
My last PR had a bug in it when dealing with multiple path params that have regexes in them. This PR fixes that, and also finishes off implementing the jax-rs spec here https://jax-rs-spec.java.net/nonav/2.0/apidocs/javax/ws/rs/Path.html by stripping spaces before and after a param name.