### PR TITLE
Issue #247

### DIFF
--- a/gson/src/test/java/feign/gson/GsonCodecTest.java
+++ b/gson/src/test/java/feign/gson/GsonCodecTest.java
@@ -130,6 +130,14 @@ public class GsonCodecTest {
     assertNull(new GsonDecoder().decode(response, String.class));
   }
 
+  @Test
+  public void emptyBodyDecodesToNull() throws Exception {
+    Response response = Response.create(204, "OK",
+                                        Collections.<String, Collection<String>>emptyMap(),
+                                        ("".getBytes()));
+    assertNull(new GsonDecoder().decode(response, String.class));
+  }
+
   private String zonesJson = ""//
                              + "[\n"//
                              + "  {\n"//

--- a/jackson/src/main/java/feign/jackson/JacksonDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonDecoder.java
@@ -52,6 +52,9 @@ public class JacksonDecoder implements Decoder {
     }
     InputStream inputStream = response.body().asInputStream();
     try {
+      if (inputStream.available() <= 0){
+        return null;
+      }
       return mapper.readValue(inputStream, mapper.constructType(type));
     } catch (RuntimeJsonMappingException e) {
       if (e.getCause() != null && e.getCause() instanceof IOException) {

--- a/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
@@ -97,6 +97,15 @@ public class JacksonCodecTest {
   }
 
   @Test
+  public void emptyBodyDecodesToNull() throws Exception {
+    Response
+        response =
+        Response
+            .create(204, "OK", Collections.<String, Collection<String>>emptyMap(), "".getBytes());
+    assertNull(new JacksonDecoder().decode(response, String.class));
+  }
+
+  @Test
   public void customDecoder() throws Exception {
     JacksonDecoder decoder = new JacksonDecoder(
         Arrays.<Module>asList(


### PR DESCRIPTION
No content to map due to end-of-input when decoding empty returns using JacksonDecoder.
Added UnitTests to show JacksonDecoder error. Added unit test to GsonDecoder to verify behavior is as expected.
Added a check for available inputStream data before trying to read into an Object.