### PR TITLE
Fixes NPE when apache client rebuffers content

### DIFF
--- a/core/src/main/java/feign/Logger.java
+++ b/core/src/main/java/feign/Logger.java
@@ -143,11 +143,6 @@ public abstract class Logger {
    * logs to the category {@link Logger} at {@link java.util.logging.Level#FINE}.
    */
   public static class ErrorLogger extends Logger {
-
-    final java.util.logging.Logger
-        logger =
-        java.util.logging.Logger.getLogger(Logger.class.getName());
-
     @Override
     protected void log(String configKey, String format, Object... args) {
       System.err.printf(methodTag(configKey) + format + "%n", args);

--- a/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
+++ b/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import feign.Feign;
 import feign.FeignException;
 import feign.Headers;
+import feign.Logger;
 import feign.RequestLine;
 import feign.Response;
 
@@ -98,6 +99,41 @@ public class OkHttpClientTest {
         .hasHeaders("Accept: text/plain", "Content-Length: 0") // Note: OkHttp adds content length.
         .hasNoHeaderNamed("Content-Type")
         .hasMethod("PATCH");
+  }
+
+  @Test
+  public void safeRebuffering() throws IOException, InterruptedException {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    TestInterface api = Feign.builder()
+        .client(new OkHttpClient())
+        .logger(new Logger(){
+          @Override
+          protected void log(String configKey, String format, Object... args) {
+          }
+        })
+        .logLevel(Logger.Level.FULL) // rebuffers the body
+        .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    api.post("foo");
+  }
+
+  /** This shows that is a no-op or otherwise doesn't cause an NPE when there's no content. */
+  @Test
+  public void safeRebuffering_noContent() throws IOException, InterruptedException {
+    server.enqueue(new MockResponse().setResponseCode(204));
+
+    TestInterface api = Feign.builder()
+        .client(new OkHttpClient())
+        .logger(new Logger(){
+          @Override
+          protected void log(String configKey, String format, Object... args) {
+          }
+        })
+        .logLevel(Logger.Level.FULL) // rebuffers the body
+        .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    api.post("foo");
   }
 
   interface TestInterface {


### PR DESCRIPTION
When log level is full, the response body is rebuffered. The Apache
client had a bug where it allowed `toInputStream` to return null. This
fixes that bug and backfills tests for the other two clients.

Fixes #255