### PR TITLE
264 body decoding

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -229,7 +229,7 @@ public final class RequestTemplate implements Serializable {
     headers.clear();
     headers.putAll(resolvedHeaders);
     if (bodyTemplate != null) {
-      body(urlDecode(expand(bodyTemplate, unencoded)));
+      body(urlDecode(expand(bodyTemplate, encoded)));
     }
     return this;
   }

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -198,6 +198,26 @@ public class RequestTemplateTest {
   }
 
   @Test
+  public void resolveTemplateWithBodyTemplateDoesNotDoubleDecode() {
+    RequestTemplate template = new RequestTemplate().method("POST")
+      .bodyTemplate(
+        "%7B\"customer_name\": \"{customer_name}\", \"user_name\": \"{user_name}\", \"password\": \"{password}\"%7D");
+
+    template = template.resolve(
+      mapOf(
+        "customer_name", "netflix",
+        "user_name", "denominator",
+        "password", "abc+123%25d8"
+      )
+    );
+
+    assertThat(template)
+      .hasBody(
+        "{\"customer_name\": \"netflix\", \"user_name\": \"denominator\", \"password\": \"abc+123%25d8\"}"
+      );
+  }
+
+  @Test
   public void skipUnresolvedQueries() throws Exception {
     RequestTemplate template = new RequestTemplate().method("GET")//
         .append("/domains/{domainId}/records")//


### PR DESCRIPTION
Fixes #264 

Switches body parameter substitution to use encoded parameters.  Resolves issue where some characters (+ %..) would end up double decoded if existing in parameters.