### PR TITLE
Skips error handling when return type is Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 8.9
+* Skips error handling when return type is `Response`
+
 ### Version 8.8
 * Adds jackson-jaxb codec
 * Bumps dependency versions for integrations

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -103,16 +103,16 @@ final class SynchronousMethodHandler implements MethodHandler {
         response =
             logger.logAndRebufferResponse(metadata.configKey(), logLevel, response, elapsedTime);
       }
+      if (Response.class == metadata.returnType()) {
+        if (response.body() == null) {
+          return response;
+        }
+        // Ensure the response body is disconnected
+        byte[] bodyData = Util.toByteArray(response.body().asInputStream());
+        return Response.create(response.status(), response.reason(), response.headers(), bodyData);
+      }
       if (response.status() >= 200 && response.status() < 300) {
-        if (Response.class == metadata.returnType()) {
-          if (response.body() == null) {
-            return response;
-          }
-          // Ensure the response body is disconnected
-          byte[] bodyData = Util.toByteArray(response.body().asInputStream());
-          return Response
-              .create(response.status(), response.reason(), response.headers(), bodyData);
-        } else if (void.class == metadata.returnType()) {
+        if (void.class == metadata.returnType()) {
           return null;
         } else {
           return decode(response);

--- a/core/src/test/java/feign/client/DefaultClientTest.java
+++ b/core/src/test/java/feign/client/DefaultClientTest.java
@@ -63,8 +63,7 @@ public class DefaultClientTest {
   public void parsesRequestAndResponse() throws IOException, InterruptedException {
     server.enqueue(new MockResponse().setBody("foo").addHeader("Foo: Bar"));
 
-    TestInterface
-        api =
+    TestInterface api =
         Feign.builder().target(TestInterface.class, "http://localhost:" + server.getPort());
 
     Response response = api.post("foo");
@@ -86,15 +85,14 @@ public class DefaultClientTest {
   @Test
   public void parsesErrorResponse() throws IOException, InterruptedException {
     thrown.expect(FeignException.class);
-    thrown.expectMessage("status 500 reading TestInterface#post(String); content:\n" + "ARGHH");
+    thrown.expectMessage("status 500 reading TestInterface#get(); content:\n" + "ARGHH");
 
     server.enqueue(new MockResponse().setResponseCode(500).setBody("ARGHH"));
 
-    TestInterface
-        api =
+    TestInterface api =
         Feign.builder().target(TestInterface.class, "http://localhost:" + server.getPort());
 
-    api.post("foo");
+    api.get();
   }
 
   /**
@@ -190,6 +188,10 @@ public class DefaultClientTest {
     @RequestLine("POST /?foo=bar&foo=baz&qux=")
     @Headers({"Foo: Bar", "Foo: Baz", "Qux: ", "Content-Type: text/plain"})
     Response post(String body);
+
+    @RequestLine("GET /")
+    @Headers("Accept: text/plain")
+    String get();
 
     @RequestLine("PATCH /")
     @Headers("Accept: text/plain")

--- a/httpclient/src/test/java/feign/httpclient/ApacheHttpClientTest.java
+++ b/httpclient/src/test/java/feign/httpclient/ApacheHttpClientTest.java
@@ -69,7 +69,7 @@ public class ApacheHttpClientTest {
   @Test
   public void parsesErrorResponse() throws IOException, InterruptedException {
     thrown.expect(FeignException.class);
-    thrown.expectMessage("status 500 reading TestInterface#post(String); content:\n" + "ARGHH");
+    thrown.expectMessage("status 500 reading TestInterface#get(); content:\n" + "ARGHH");
 
     server.enqueue(new MockResponse().setResponseCode(500).setBody("ARGHH"));
 
@@ -77,7 +77,7 @@ public class ApacheHttpClientTest {
         .client(new ApacheHttpClient())
         .target(TestInterface.class, "http://localhost:" + server.getPort());
 
-    api.post("foo");
+    api.get();
   }
 
   @Test
@@ -137,6 +137,10 @@ public class ApacheHttpClientTest {
     @RequestLine("POST /?foo=bar&foo=baz&qux=")
     @Headers({"Foo: Bar", "Foo: Baz", "Qux: ", "Content-Type: text/plain"})
     Response post(String body);
+
+    @RequestLine("GET /")
+    @Headers("Accept: text/plain")
+    String get();
 
     @RequestLine("PATCH /")
     @Headers("Accept: text/plain")

--- a/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
+++ b/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
@@ -18,7 +18,6 @@ package feign.okhttp;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -72,7 +71,7 @@ public class OkHttpClientTest {
   @Test
   public void parsesErrorResponse() throws IOException, InterruptedException {
     thrown.expect(FeignException.class);
-    thrown.expectMessage("status 500 reading TestInterface#post(String); content:\n" + "ARGHH");
+    thrown.expectMessage("status 500 reading TestInterface#get(); content:\n" + "ARGHH");
 
     server.enqueue(new MockResponse().setResponseCode(500).setBody("ARGHH"));
 
@@ -80,11 +79,10 @@ public class OkHttpClientTest {
         .client(new OkHttpClient())
         .target(TestInterface.class, "http://localhost:" + server.getPort());
 
-    api.post("foo");
+    api.get();
   }
 
   @Test
-  @Ignore // TODO: Remove on OkHttp 2.5 https://github.com/square/okhttp/issues/1778
   public void patch() throws IOException, InterruptedException {
     server.enqueue(new MockResponse().setBody("foo"));
     server.enqueue(new MockResponse());
@@ -93,7 +91,7 @@ public class OkHttpClientTest {
         .client(new OkHttpClient())
         .target(TestInterface.class, "http://localhost:" + server.getPort());
 
-    assertEquals("foo", api.patch());
+    assertEquals("foo", api.patch(""));
 
     assertThat(server.takeRequest())
         .hasHeaders("Accept: text/plain", "Content-Length: 0") // Note: OkHttp adds content length.
@@ -142,8 +140,12 @@ public class OkHttpClientTest {
     @Headers({"Foo: Bar", "Foo: Baz", "Qux: ", "Content-Type: text/plain"})
     Response post(String body);
 
+    @RequestLine("GET /")
+    @Headers("Accept: text/plain")
+    String get();
+
     @RequestLine("PATCH /")
     @Headers("Accept: text/plain")
-    String patch();
+    String patch(String body);
   }
 }


### PR DESCRIPTION
In unsuccessful scenarios, such as redirects, error handling converts a
`Response` into an exception. When a user defines a return type as
`Response`, we can assume they will want access to things like headers
even in an error scenario.

See #249