### PR TITLE
Class-level headers from inherited class

### DIFF
--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -82,10 +82,11 @@ public interface Contract {
       data.returnType(Types.resolve(targetType, targetType, method.getGenericReturnType()));
       data.configKey(Feign.configKey(targetType, method));
 
-      processAnnotationOnClass(data, method.getDeclaringClass());
-      if (method.getDeclaringClass() != targetType) {
-        processAnnotationOnClass(data, targetType);
+      if(targetType.getInterfaces().length == 1) {
+        processAnnotationOnClass(data, targetType.getInterfaces()[0]);
       }
+      processAnnotationOnClass(data, targetType);
+
 
       for (Annotation methodAnnotation : method.getAnnotations()) {
         processAnnotationOnMethod(data, methodAnnotation, method);


### PR DESCRIPTION
Before, class annotations was only looked at if the method was declared in the parent interface. If method was declared in main interface, parent class was not looked at.

Adds more useful functionality to my prev pull req #266.

