### PR TITLE
Proof of concept for Visitor-pattern-based handling of Responses

### DIFF
--- a/core/src/main/java/feign/DefaultResponseHandlers.java
+++ b/core/src/main/java/feign/DefaultResponseHandlers.java
@@ -1,0 +1,87 @@
+package feign;
+
+import feign.codec.DecodeException;
+import feign.codec.Decoder;
+import feign.codec.ErrorDecoder;
+
+import java.io.IOException;
+
+public class DefaultResponseHandlers {
+
+  /**
+   * Handles responses if the method's return type (indicated by {@link MethodMetadata#returnType})
+   * is {@code Response.class}.
+   */
+  public static class ResponseResponseHandler implements ResponseHandler {
+    @Override
+    public boolean handle(Response response, MethodMetadata metadata, ResultHolder result)
+        throws IOException {
+
+      if (Response.class == metadata.returnType()) {
+        if (response.body() == null) {
+          result.setResult(response);
+        } else {
+          // Ensure the response body is disconnected
+          byte[] bodyData = Util.toByteArray(response.body().asInputStream());
+          result.setResult(Response.create(response.status(), response.reason(), response.headers(), bodyData));
+        }
+        return true; // handled successfully
+
+      } else {
+        return false; // did not handle
+      }
+    }
+  }
+
+  /**
+   * Accepts responses with error code [200, 300) and decodes the response using the provided {@link Decoder}.
+   */
+  public static class DecodingReponseHandler implements ResponseHandler {
+    private final Decoder decoder;
+
+    public DecodingReponseHandler(Decoder decoder) {
+      this.decoder = decoder;
+    }
+
+    @Override
+    public boolean handle(Response response, MethodMetadata metadata, ResultHolder result) throws Throwable {
+      if (response.status() >= 200 && response.status() < 300) {
+        if (void.class == metadata.returnType()) {
+          result.setResult(null);
+        } else {
+          result.setResult(decode(response, metadata));
+        }
+
+        return true; // handled successfully
+      } else {
+        return false; // not handled
+      }
+    }
+
+    private Object decode(Response response, MethodMetadata metadata) throws Throwable {
+      try {
+        return decoder.decode(response, metadata.returnType());
+      } catch (FeignException e) {
+        throw e;
+      } catch (RuntimeException e) {
+        throw new DecodeException(e.getMessage(), e);
+      }
+    }
+  }
+
+  /**
+   * Handles every response by throwing the exception produced by the given {@link ErrorDecoder}, never returns true.
+   */
+  public static class ErrorResponseHandler implements ResponseHandler {
+    private final ErrorDecoder errorDecoder;
+
+    public ErrorResponseHandler(ErrorDecoder errorDecoder) {
+      this.errorDecoder = errorDecoder;
+    }
+
+    @Override
+    public boolean handle(Response response, MethodMetadata metadata, ResultHolder result) throws Exception {
+      throw errorDecoder.decode(metadata.configKey(), response);
+    }
+  }
+}

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -91,8 +91,7 @@ public abstract class Feign {
     private Retryer retryer = new Retryer.Default();
     private Logger logger = new NoOpLogger();
     private Encoder encoder = new Encoder.Default();
-    private Decoder decoder = new Decoder.Default();
-    private ErrorDecoder errorDecoder = new ErrorDecoder.Default();
+    private Iterable<ResponseHandler> responseHandlers;
     private Options options = new Options();
     private InvocationHandlerFactory
         invocationHandlerFactory =
@@ -128,13 +127,8 @@ public abstract class Feign {
       return this;
     }
 
-    public Builder decoder(Decoder decoder) {
-      this.decoder = decoder;
-      return this;
-    }
-
-    public Builder errorDecoder(ErrorDecoder errorDecoder) {
-      this.errorDecoder = errorDecoder;
+    public Builder reponseHandlers(Iterable<ResponseHandler> responseHandlers) {
+      this.responseHandlers = responseHandlers;
       return this;
     }
 
@@ -181,12 +175,9 @@ public abstract class Feign {
 
     public Feign build() {
       SynchronousMethodHandler.Factory synchronousMethodHandlerFactory =
-          new SynchronousMethodHandler.Factory(client, retryer, requestInterceptors, logger,
-                                               logLevel);
-      ParseHandlersByName
-          handlersByName =
-          new ParseHandlersByName(contract, options, encoder, decoder,
-                                  errorDecoder, synchronousMethodHandlerFactory);
+          new SynchronousMethodHandler.Factory(client, retryer, requestInterceptors, logger, logLevel);
+      ParseHandlersByName handlersByName =
+          new ParseHandlersByName(contract, options, encoder, responseHandlers, synchronousMethodHandlerFactory);
       return new ReflectiveFeign(handlersByName, invocationHandlerFactory);
     }
   }

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -119,18 +119,16 @@ public class ReflectiveFeign extends Feign {
     private final Contract contract;
     private final Options options;
     private final Encoder encoder;
-    private final Decoder decoder;
-    private final ErrorDecoder errorDecoder;
+    private final Iterable<ResponseHandler> responseHandlers;
     private final SynchronousMethodHandler.Factory factory;
 
-    ParseHandlersByName(Contract contract, Options options, Encoder encoder, Decoder decoder,
-                        ErrorDecoder errorDecoder, SynchronousMethodHandler.Factory factory) {
+    ParseHandlersByName(Contract contract, Options options, Encoder encoder,
+                        Iterable<ResponseHandler> responseHandlers, SynchronousMethodHandler.Factory factory) {
       this.contract = contract;
       this.options = options;
+      this.responseHandlers = checkNotNull(responseHandlers, "responseHandlers");
       this.factory = factory;
-      this.errorDecoder = errorDecoder;
       this.encoder = checkNotNull(encoder, "encoder");
-      this.decoder = checkNotNull(decoder, "decoder");
     }
 
     public Map<String, MethodHandler> apply(Target key) {
@@ -146,7 +144,7 @@ public class ReflectiveFeign extends Feign {
           buildTemplate = new BuildTemplateByResolvingArgs(md);
         }
         result.put(md.configKey(),
-                   factory.create(key, md, buildTemplate, options, decoder, errorDecoder));
+                   factory.create(key, md, buildTemplate, options, responseHandlers));
       }
       return result;
     }

--- a/core/src/main/java/feign/ResponseHandler.java
+++ b/core/src/main/java/feign/ResponseHandler.java
@@ -1,0 +1,26 @@
+package feign;
+
+public interface ResponseHandler {
+
+  /**
+   * If this handler can handle the given {@link Response}, returns the decoded response into {@code result} and
+   * returns true; else returns false. Throws in case of internal errors or in case the given response should be
+   * surfaced as an error, e.g., when the response has error code 404.
+   */
+  boolean handle(Response response, MethodMetadata metadata, ResultHolder result) throws Throwable;
+
+  /**
+   * Mutable Object wrapper for holding/returning the result of a handler; null is a valid result.
+   */
+  class ResultHolder {
+    private Object result = null;
+
+    public Object getResult() {
+      return result;
+    }
+
+    public void setResult(Object result) {
+      this.result = result;
+    }
+  }
+}


### PR DESCRIPTION
Hi @adriancole ,

This pull-request is a proof-of-concept for making response handling more flexible. (Note that I haven't fixed up the tests, so it doesn't compile.) The motivation is as follows: Our servers often return 404s for non-existing resources and we'd like to surface those as Optional#absent (Guava or Java8) in clients, rather than as exceptions. Given the current architecture of response handling in SynchronousResponseHandler this is not possible since the configured Decoder is only invoked for [200, 300) error codes. This PR shows how to use a Visitor pattern to make response handling more flexible and configurable.

I'd like to know if you'd in principle be happy to consider this or a similar approach, or if you are opposed based on some fundamental consideration. In the former case, I'm happy to get APIs and tests in good shape according to your suggestions. Back-compat of the Feign.Builder class will be an issue.

Cheers!
  Robert