### PR TITLE
Adds Feign.Builder.decode404() to reduce boilerplate for empty semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 8.12
+* Adds `Feign.Builder.decode404()` to reduce boilerplate for empty semantics.
+
 ### Version 8.11
 * Adds support for Hystrix via a `HystrixFeign` builder.
 

--- a/core/src/main/java/feign/codec/Decoder.java
+++ b/core/src/main/java/feign/codec/Decoder.java
@@ -67,19 +67,15 @@ public interface Decoder {
    */
   Object decode(Response response, Type type) throws IOException, DecodeException, FeignException;
 
-  /**
-   * Default implementation of {@code Decoder}.
-   */
+  /** Default implementation of {@code Decoder}. */
   public class Default extends StringDecoder {
 
     @Override
     public Object decode(Response response, Type type) throws IOException {
-      Response.Body body = response.body();
-      if (body == null) {
-        return null;
-      }
+      if (response.status() == 404) return Util.emptyValueOf(type);
+      if (response.body() == null) return null;
       if (byte[].class.equals(type)) {
-        return Util.toByteArray(body.asInputStream());
+        return Util.toByteArray(response.body().asInputStream());
       }
       return super.decode(response, type);
     }

--- a/core/src/main/java/feign/codec/ErrorDecoder.java
+++ b/core/src/main/java/feign/codec/ErrorDecoder.java
@@ -35,25 +35,35 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Allows you to massage an exception into a application-specific one. Converting out to a throttle
- * exception are examples of this in use. <br> Ex. <br>
+ * exception are examples of this in use.
+ *
+ * <p/>Ex:
  * <pre>
  * class IllegalArgumentExceptionOn404Decoder extends ErrorDecoder {
  *
  *   &#064;Override
  *   public Exception decode(String methodKey, Response response) {
- *    if (response.status() == 404)
- *        throw new IllegalArgumentException(&quot;zone not found&quot;);
+ *    if (response.status() == 400)
+ *        throw new IllegalArgumentException(&quot;bad zone name&quot;);
  *    return ErrorDecoder.DEFAULT.decode(methodKey, request, response);
  *   }
  *
  * }
  * </pre>
- * <br> <b>Error handling</b><br> <br> Responses where {@link Response#status()} is not in the 2xx
+ *
+ * <p/><b>Error handling</b>
+ *
+ * <p/>Responses where {@link Response#status()} is not in the 2xx
  * range are classified as errors, addressed by the {@link ErrorDecoder}. That said, certain RPC
  * apis return errors defined in the {@link Response#body()} even on a 200 status. For example, in
  * the DynECT api, a job still running condition is returned with a 200 status, encoded in json.
  * When scenarios like this occur, you should raise an application-specific exception (which may be
  * {@link feign.RetryableException retryable}).
+ *
+ * <p/><b>Not Found Semantics</b>
+ * <p/> It is commonly the case that 404 (Not Found) status has semantic value in HTTP apis. While
+ * the default behavior is to raise exeception, users can alternatively enable 404 processing via
+ * {@link feign.Feign.Builder#decode404()}.
  */
 public interface ErrorDecoder {
 

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -231,12 +231,12 @@ public class FeignTest {
 
   @Test
   public void canOverrideErrorDecoder() throws Exception {
-    server.enqueue(new MockResponse().setResponseCode(404).setBody("foo"));
+    server.enqueue(new MockResponse().setResponseCode(400).setBody("foo"));
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("zone not found");
+    thrown.expectMessage("bad zone name");
 
     TestInterface api = new TestInterfaceBuilder()
-        .errorDecoder(new IllegalArgumentExceptionOn404())
+        .errorDecoder(new IllegalArgumentExceptionOn400())
         .target("http://localhost:" + server.getPort());
 
     api.post();
@@ -548,12 +548,12 @@ public class FeignTest {
     }
   }
 
-  static class IllegalArgumentExceptionOn404 extends ErrorDecoder.Default {
+  static class IllegalArgumentExceptionOn400 extends ErrorDecoder.Default {
 
     @Override
     public Exception decode(String methodKey, Response response) {
-      if (response.status() == 404) {
-        return new IllegalArgumentException("zone not found");
+      if (response.status() == 400) {
+        return new IllegalArgumentException("bad zone name");
       }
       return super.decode(methodKey, response);
     }

--- a/core/src/test/java/feign/UtilTest.java
+++ b/core/src/test/java/feign/UtilTest.java
@@ -19,19 +19,50 @@ import org.junit.Test;
 
 import java.io.Reader;
 import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import feign.codec.Decoder;
 
 import static feign.Util.resolveLastTypeParameter;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class UtilTest {
 
   @Test
+  public void emptyValueOf() throws Exception {
+    assertEquals(false, Util.emptyValueOf(boolean.class));
+    assertEquals(false, Util.emptyValueOf(Boolean.class));
+    assertThat((byte[]) Util.emptyValueOf(byte[].class)).isEmpty();
+    assertEquals(Collections.emptyList(), Util.emptyValueOf(Collection.class));
+    assertThat((Iterator<?>) Util.emptyValueOf(Iterator.class)).isEmpty();
+    assertEquals(Collections.emptyList(), Util.emptyValueOf(List.class));
+    assertEquals(Collections.emptyMap(), Util.emptyValueOf(Map.class));
+    assertEquals(Collections.emptySet(), Util.emptyValueOf(Set.class));
+  }
+
+  /** In other words, {@code List<String>} is as empty as {@code List<?>}. */
+  @Test
+  public void emptyValueOf_considersRawType() throws Exception {
+    Type listStringType = LastTypeParameter.class.getDeclaredField("LIST_STRING").getGenericType();
+    assertThat((List<?>) Util.emptyValueOf(listStringType)).isEmpty();
+  }
+
+  /** Ex. your {@code Foo} object would be null, but so would things like Number. */
+  @Test
+  public void emptyValueOf_nullForUndefined() throws Exception {
+    assertThat(Util.emptyValueOf(Number.class)).isNull();
+    assertThat(Util.emptyValueOf(Parameterized.class)).isNull();
+  }
+
+  @Test
   public void resolveLastTypeParameterWhenNotSubtype() throws Exception {
-    Type
-        context =
+    Type context =
         LastTypeParameter.class.getDeclaredField("PARAMETERIZED_LIST_STRING").getGenericType();
     Type listStringType = LastTypeParameter.class.getDeclaredField("LIST_STRING").getGenericType();
     Type last = resolveLastTypeParameter(context, Parameterized.class);
@@ -40,14 +71,14 @@ public class UtilTest {
 
   @Test
   public void lastTypeFromInstance() throws Exception {
-    Parameterized instance = new ParameterizedSubtype();
+    Parameterized<?> instance = new ParameterizedSubtype();
     Type last = resolveLastTypeParameter(instance.getClass(), Parameterized.class);
     assertEquals(String.class, last);
   }
 
   @Test
   public void lastTypeFromAnonymous() throws Exception {
-    Parameterized instance = new Parameterized<Reader>() {
+    Parameterized<?> instance = new Parameterized<Reader>() {
     };
     Type last = resolveLastTypeParameter(instance.getClass(), Parameterized.class);
     assertEquals(Reader.class, last);
@@ -55,8 +86,7 @@ public class UtilTest {
 
   @Test
   public void resolveLastTypeParameterWhenWildcard() throws Exception {
-    Type
-        context =
+    Type context =
         LastTypeParameter.class.getDeclaredField("PARAMETERIZED_WILDCARD_LIST_STRING")
             .getGenericType();
     Type listStringType = LastTypeParameter.class.getDeclaredField("LIST_STRING").getGenericType();
@@ -66,8 +96,7 @@ public class UtilTest {
 
   @Test
   public void resolveLastTypeParameterWhenParameterizedSubtype() throws Exception {
-    Type
-        context =
+    Type context =
         LastTypeParameter.class.getDeclaredField("PARAMETERIZED_DECODER_LIST_STRING")
             .getGenericType();
     Type listStringType = LastTypeParameter.class.getDeclaredField("LIST_STRING").getGenericType();
@@ -77,15 +106,13 @@ public class UtilTest {
 
   @Test
   public void unboundWildcardIsObject() throws Exception {
-    Type
-        context =
+    Type context =
         LastTypeParameter.class.getDeclaredField("PARAMETERIZED_DECODER_UNBOUND").getGenericType();
     Type last = resolveLastTypeParameter(context, ParameterizedDecoder.class);
     assertEquals(Object.class, last);
   }
 
   interface LastTypeParameter {
-
     final List<String> LIST_STRING = null;
     final Parameterized<List<String>> PARAMETERIZED_LIST_STRING = null;
     final Parameterized<? extends List<String>> PARAMETERIZED_WILDCARD_LIST_STRING = null;

--- a/gson/src/main/java/feign/gson/GsonDecoder.java
+++ b/gson/src/main/java/feign/gson/GsonDecoder.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 
 import feign.Response;
+import feign.Util;
 import feign.codec.Decoder;
 
 import static feign.Util.ensureClosed;
@@ -47,9 +48,8 @@ public class GsonDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException {
-    if (response.body() == null) {
-      return null;
-    }
+    if (response.status() == 404) return Util.emptyValueOf(type);
+    if (response.body() == null) return null;
     Reader reader = response.body().asReader();
     try {
       return gson.fromJson(reader, type);

--- a/gson/src/test/java/feign/gson/GsonCodecTest.java
+++ b/gson/src/test/java/feign/gson/GsonCodecTest.java
@@ -210,4 +210,13 @@ public class GsonCodecTest {
                                  + "  }\n" //
                                  + "]");
   }
+
+  /** Enabled via {@link feign.Feign.Builder#decode404()} */
+  @Test
+  public void notFoundDecodesToEmpty() throws Exception {
+    Response response = Response.create(404, "NOT FOUND",
+        Collections.<String, Collection<String>>emptyMap(),
+        (byte[]) null);
+    assertThat((byte[]) new GsonDecoder().decode(response, byte[].class)).isEmpty();
+  }
 }

--- a/jackson-jaxb/src/main/java/feign/jackson/jaxb/JacksonJaxbJsonDecoder.java
+++ b/jackson-jaxb/src/main/java/feign/jackson/jaxb/JacksonJaxbJsonDecoder.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Type;
 
 import feign.FeignException;
 import feign.Response;
+import feign.Util;
 import feign.codec.Decoder;
 
 import static com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider.DEFAULT_ANNOTATIONS;
@@ -26,6 +27,8 @@ public final class JacksonJaxbJsonDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException, FeignException {
+    if (response.status() == 404) return Util.emptyValueOf(type);
+    if (response.body() == null) return null;
     return jacksonJaxbJsonProvider.readFrom(Object.class, type, null, APPLICATION_JSON_TYPE, null, response.body().asInputStream());
   }
 }

--- a/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
+++ b/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
@@ -38,6 +38,15 @@ public class JacksonJaxbCodecTest {
         .isEqualTo(new MockObject("Test"));
   }
 
+  /** Enabled via {@link feign.Feign.Builder#decode404()} */
+  @Test
+  public void notFoundDecodesToEmpty() throws Exception {
+    Response response = Response.create(404, "NOT FOUND",
+        Collections.<String, Collection<String>>emptyMap(),
+        (byte[]) null);
+    assertThat((byte[]) new JacksonJaxbJsonDecoder().decode(response, byte[].class)).isEmpty();
+  }
+
   @XmlRootElement
   @XmlAccessorType(XmlAccessType.FIELD)
   static class MockObject {

--- a/jackson/src/main/java/feign/jackson/JacksonDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonDecoder.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 
 import feign.Response;
+import feign.Util;
 import feign.codec.Decoder;
 
 public class JacksonDecoder implements Decoder {
@@ -48,9 +49,8 @@ public class JacksonDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException {
-    if (response.body() == null) {
-      return null;
-    }
+    if (response.status() == 404) return Util.emptyValueOf(type);
+    if (response.body() == null) return null;
     Reader reader = response.body().asReader();
     if (!reader.markSupported()) {
       reader = new BufferedReader(reader, 1);

--- a/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
@@ -201,4 +201,13 @@ public class JacksonCodecTest {
       jgen.writeEndObject();
     }
   }
+
+  /** Enabled via {@link feign.Feign.Builder#decode404()} */
+  @Test
+  public void notFoundDecodesToEmpty() throws Exception {
+    Response response = Response.create(404, "NOT FOUND",
+        Collections.<String, Collection<String>>emptyMap(),
+        (byte[]) null);
+    assertThat((byte[]) new JacksonDecoder().decode(response, byte[].class)).isEmpty();
+  }
 }

--- a/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
@@ -22,6 +22,7 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 
 import feign.Response;
+import feign.Util;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 
@@ -50,6 +51,8 @@ public class JAXBDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException {
+    if (response.status() == 404) return Util.emptyValueOf(type);
+    if (response.body() == null) return null;
     if (!(type instanceof Class)) {
       throw new UnsupportedOperationException(
           "JAXB only supports decoding raw types. Found " + type);

--- a/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -198,6 +198,16 @@ public class JAXBCodecTest {
     new JAXBDecoder(new JAXBContextFactory.Builder().build()).decode(response, parameterized);
   }
 
+  /** Enabled via {@link feign.Feign.Builder#decode404()} */
+  @Test
+  public void notFoundDecodesToEmpty() throws Exception {
+    Response response = Response.create(404, "NOT FOUND",
+        Collections.<String, Collection<String>>emptyMap(),
+        (byte[]) null);
+    assertThat((byte[]) new JAXBDecoder(new JAXBContextFactory.Builder().build())
+        .decode(response, byte[].class)).isEmpty();
+  }
+
   @XmlRootElement
   @XmlAccessorType(XmlAccessType.FIELD)
   static class MockObject {

--- a/sax/src/main/java/feign/sax/SAXDecoder.java
+++ b/sax/src/main/java/feign/sax/SAXDecoder.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import feign.Response;
+import feign.Util;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 
@@ -63,9 +64,8 @@ public class SAXDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException, DecodeException {
-    if (response.body() == null) {
-      return null;
-    }
+    if (response.status() == 404) return Util.emptyValueOf(type);
+    if (response.body() == null) return null;
     ContentHandlerWithResult.Factory<?> handlerFactory = handlerFactories.get(type);
     checkState(handlerFactory != null, "type %s not in configured handlers %s", type,
                handlerFactories.keySet());

--- a/sax/src/test/java/feign/sax/SAXDecoderTest.java
+++ b/sax/src/test/java/feign/sax/SAXDecoderTest.java
@@ -29,6 +29,7 @@ import feign.Response;
 import feign.codec.Decoder;
 
 import static feign.Util.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -79,11 +80,19 @@ public class SAXDecoderTest {
 
   @Test
   public void nullBodyDecodesToNull() throws Exception {
-    Response
-        response =
+    Response response =
         Response
             .create(204, "OK", Collections.<String, Collection<String>>emptyMap(), (byte[]) null);
     assertNull(decoder.decode(response, String.class));
+  }
+
+  /** Enabled via {@link feign.Feign.Builder#decode404()} */
+  @Test
+  public void notFoundDecodesToEmpty() throws Exception {
+    Response response = Response.create(404, "NOT FOUND",
+        Collections.<String, Collection<String>>emptyMap(),
+        (byte[]) null);
+    assertThat((byte[]) decoder.decode(response, byte[].class)).isEmpty();
   }
 
   static enum NetworkStatus {


### PR DESCRIPTION
This adds the `Feign.Builder.decode404()` flag which indicates decoders
should process responses with 404 status. It also changes all
first-party decoders (like gson) to return well-known empty values by
default. Further customization is possible by wrapping or creating a
custom decoder.

#### On why we aren't opening all codes

Prior to this change, we used custom invocation handlers as the way to
add fallback values based on exception or return status. `feign-hystrix`
uses this to return `HystrixCommand<X>`, but the general pattern applies
to anything that has a type representing both success and failure, such
as `Try<X>` or `Observable<X>`.

As we define it here, 404 status is not a retry or fallback policy, it
is just empty semantics. By limiting Feign's special processing to 404,
we gain a lot with very little supporting code.

If instead we opened all codes, Feign could easily turn bad request,
redirect, or server errors silently to null. This sort of configuration 
issue is hard to troubleshoot. 404 -> empty is a very safe policy vs 
all codes.

Moreover, we don't create a cliff, where folks seeking fallback policy 
eventually realize they can't if only given a response code. Fallback
systems like Hystrix address exceptions that occur before or in lieu of
a response. By special-casing 404, we avoid a slippery slope of half-
implementing Hystrix.

Finally, 404 handling has been commonly requested: it has a clear use-
case, and through that value. This design supports that without breaking
compatibility, or impacting existing integrations such as Hystrix or 
Ribbon.

See #238 #287