### PR TITLE
SynchronousMethodHandler no longer wraps Decoder#decode unchecked exc…

### DIFF
--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -121,7 +121,7 @@ final class SynchronousMethodHandler implements MethodHandler {
           return decode(response);
         }
       } else if (decode404 && response.status() == 404) {
-        return decode(response);
+        return decoder.decode(response, metadata.returnType());
       } else {
         throw errorDecoder.decode(metadata.configKey(), response);
       }

--- a/core/src/main/java/feign/codec/Decoder.java
+++ b/core/src/main/java/feign/codec/Decoder.java
@@ -18,6 +18,7 @@ package feign.codec;
 import java.io.IOException;
 import java.lang.reflect.Type;
 
+import feign.Feign;
 import feign.FeignException;
 import feign.Response;
 import feign.Util;
@@ -49,6 +50,9 @@ import feign.Util;
  * feign.Target#type() interface} processed by {@link feign.Feign#newInstance(feign.Target)}.  When
  * writing your implementation of Decoder, ensure you also test parameterized types such as {@code
  * List<Foo>}.
+ * <br/> <h3>Note on exception propagation</h3> Exceptions thrown by {@link Decoder}s get wrapped in
+ * a {@link DecodeException} unless they are a subclass of {@link FeignException} already, and unless
+ * the client was configured with {@link Feign.Builder#decode404()}.
  */
 public interface Decoder {
 


### PR DESCRIPTION
…eptions in DecodeException

Removing exception wrapping adds flexibility to the interplay of Decoder and ErrorDecoder:
A Decoder can now delegate to an ErrorDecoder and the original ErrorDecoder exception gets
thrown rather than a Feign-specific DecodeException. An example use-case is a Jackson/Gson
implementation of special 404-handling of Optional<Foo> methods: when the Feign client has
decode404() enabled, then the Decoder is in charge of dispatching 404 to Optional#absent
where applicable, or to a delegate ErrorDecoder otherwise; consistent exception handling
requires that the exception produced by the ErrorDecoder does not wrapped.