### PR TITLE
Allow responses to be streamed.

### DIFF
--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -36,7 +36,7 @@ import static feign.Util.valuesOrEmpty;
 /**
  * An immutable response to an http invocation which only returns string content.
  */
-public final class Response {
+public final class Response implements Closeable {
 
   private final int status;
   private final String reason;
@@ -112,6 +112,11 @@ public final class Response {
       builder.append('\n').append(body);
     }
     return builder.toString();
+  }
+
+  @Override
+  public void close() {
+    Util.ensureClosed(body);
   }
 
   public interface Body extends Closeable {

--- a/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
+++ b/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
@@ -195,7 +195,7 @@ public final class ApacheHttpClient implements Client {
 
       @Override
       public Integer length() {
-        return entity.getContentLength() < 0 ? (int) entity.getContentLength() : null;
+        return entity.getContentLength() >= 0 ? (int) entity.getContentLength() : null;
       }
 
       @Override

--- a/httpclient/src/test/java/feign/httpclient/ApacheHttpClientTest.java
+++ b/httpclient/src/test/java/feign/httpclient/ApacheHttpClientTest.java
@@ -60,6 +60,7 @@ public class ApacheHttpClientTest {
     assertThat(response.headers())
         .containsEntry("Content-Length", asList("3"))
         .containsEntry("Foo", asList("Bar"));
+    assertThat(response.body().length()).isEqualTo(3);
     assertThat(response.body().asInputStream())
         .hasContentEqualTo(new ByteArrayInputStream("foo".getBytes(UTF_8)));
 
@@ -67,6 +68,22 @@ public class ApacheHttpClientTest {
         .hasPath("/?foo=bar&foo=baz&qux=")
         .hasHeaders("Foo: Bar", "Foo: Baz", "Qux: ", "Accept: */*", "Content-Length: 3")
         .hasBody("foo");
+  }
+
+  @Test
+  public void parsesResponseMissingLength() throws IOException, InterruptedException {
+    server.enqueue(new MockResponse().setChunkedBody("foo", 1));
+
+    TestInterface api = Feign.builder()
+        .client(new ApacheHttpClient())
+        .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    Response response = api.post("testing");
+    assertThat(response.status()).isEqualTo(200);
+    assertThat(response.reason()).isEqualTo("OK");
+    assertThat(response.body().length()).isNull();
+    assertThat(response.body().asInputStream())
+        .hasContentEqualTo(new ByteArrayInputStream("foo".getBytes(UTF_8)));
   }
 
   @Test


### PR DESCRIPTION
Never expands >8kb responses into memory

It seems less dangerous to avoid closing Response objects than to explode large responses in memory