### PR TITLE
Add support for Observable return type to Hystrix module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 8.14
+* Add support for RxJava Observable and Single return types via the `HystrixFeign` builder.
+
 ### Version 8.13
 * Never expands >8kb responses into memory
 * Bumps dependency versions, most notably Gson 2.5 and OkHttp 2.7

--- a/hystrix/README.md
+++ b/hystrix/README.md
@@ -10,15 +10,23 @@ GitHub github = HystrixFeign.builder()
         .target(GitHub.class, "https://api.github.com");
 ```
 
-Methods that do *not* return [`HystrixCommand`](https://netflix.github.io/Hystrix/javadoc/com/netflix/hystrix/HystrixCommand.html) are still wrapped in a `HystrixCommand`, but `execute()` is automatically called for you.
+For asynchronous or reactive use, return `HystrixCommand<YourType>`.
 
-For asynchronous or reactive use, return `HystrixCommand<YourType>` rather than just `YourType`.
+For RxJava compatibility, use `rx.Observable<YourType>` or `rx.Single<YourType>`. Rx types are <a href="http://reactivex.io/documentation/observable.html">cold</a>, which means a http call isn't made until there's a subscriber.
+
+Methods that do *not* return [`HystrixCommand`](https://netflix.github.io/Hystrix/javadoc/com/netflix/hystrix/HystrixCommand.html), [`rx.Observable`](http://reactivex.io/RxJava/javadoc/rx/Observable.html) or [`rx.Single`] are still wrapped in a `HystrixCommand`, but `execute()` is automatically called for you.
 
 ```java
 interface YourApi {
   @RequestLine("GET /yourtype/{id}")
   HystrixCommand<YourType> getYourType(@Param("id") String id);
-  
+
+  @RequestLine("GET /yourtype/{id}")
+  Observable<YourType> getYourTypeObservable(@Param("id") String id);
+
+  @RequestLine("GET /yourtype/{id}")
+  Single<YourType> getYourTypeSingle(@Param("id") String id);
+
   @RequestLine("GET /yourtype/{id}")
   YourType getYourTypeSynchronous(@Param("id") String id);
 }
@@ -27,7 +35,10 @@ YourApi api = HystrixFeign.builder()
                   .target(YourApi.class, "https://example.com");
 
 // for reactive
-api.getYourType("a").toObservable();
+api.getYourTypeObservable("a").toObservable
+
+// or apply hystrix to RxJava methods
+api.getYourTypeObservable("a")
 
 // for asynchronous
 api.getYourType("a").queue();

--- a/hystrix/src/main/java/feign/hystrix/HystrixDelegatingContract.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixDelegatingContract.java
@@ -10,12 +10,14 @@ import com.netflix.hystrix.HystrixCommand;
 
 import feign.Contract;
 import feign.MethodMetadata;
+import rx.Observable;
+import rx.Single;
 
 /**
- * This special cases methods that return {@link HystrixCommand}, so that they
+ * This special cases methods that return {@link HystrixCommand}, {@link Observable}, or {@link Single} so that they
  * are decoded properly.
  * 
- * <p>For example, {@literal HystrixCommand<Foo>} will decode {@code Foo}.
+ * <p>For example, {@literal HystrixCommand<Foo>} and {@literal Observable<Foo>} will decode {@code Foo}.
  */
 // Visible for use in custom Hystrix invocation handlers
 public final class HystrixDelegatingContract implements Contract {
@@ -35,6 +37,12 @@ public final class HystrixDelegatingContract implements Contract {
 
       if (type instanceof ParameterizedType && ((ParameterizedType) type).getRawType().equals(HystrixCommand.class)) {
         Type actualType = resolveLastTypeParameter(type, HystrixCommand.class);
+        metadata.returnType(actualType);
+      } else if (type instanceof ParameterizedType && ((ParameterizedType) type).getRawType().equals(Observable.class)) {
+        Type actualType = resolveLastTypeParameter(type, Observable.class);
+        metadata.returnType(actualType);
+      } else if (type instanceof ParameterizedType && ((ParameterizedType) type).getRawType().equals(Single.class)) {
+        Type actualType = resolveLastTypeParameter(type, Single.class);
         metadata.returnType(actualType);
       }
     }

--- a/hystrix/src/main/java/feign/hystrix/HystrixFeign.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixFeign.java
@@ -6,7 +6,7 @@ import feign.Contract;
 import feign.Feign;
 
 /**
- * Allows Feign interfaces to return HystrixCommand objects.
+ * Allows Feign interfaces to return HystrixCommand or rx.Observable or rx.Single objects.
  * Also decorates normal Feign methods with circuit breakers, but calls {@link HystrixCommand#execute()} directly.
  */
 public final class HystrixFeign {

--- a/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
@@ -28,6 +28,8 @@ import com.netflix.hystrix.HystrixCommandKey;
 import feign.InvocationHandlerFactory;
 import feign.InvocationHandlerFactory.MethodHandler;
 import feign.Target;
+import rx.Observable;
+import rx.Single;
 
 final class HystrixInvocationHandler implements InvocationHandler {
 
@@ -62,6 +64,12 @@ final class HystrixInvocationHandler implements InvocationHandler {
 
     if (HystrixCommand.class.isAssignableFrom(method.getReturnType())) {
       return hystrixCommand;
+    } else if (Observable.class.isAssignableFrom(method.getReturnType())) {
+      // Create a cold Observable
+      return hystrixCommand.toObservable();
+    } else if (Single.class.isAssignableFrom(method.getReturnType())) {
+      // Create a cold Observable as a Single
+      return hystrixCommand.toObservable().toSingle();
     }
     return hystrixCommand.execute();
   }

--- a/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
+++ b/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
@@ -2,8 +2,10 @@ package feign.hystrix;
 
 import static feign.assertj.MockWebServerAssertions.assertThat;
 
+import java.util.Arrays;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -15,6 +17,9 @@ import com.squareup.okhttp.mockwebserver.MockWebServer;
 import feign.Headers;
 import feign.RequestLine;
 import feign.gson.GsonDecoder;
+import rx.Observable;
+import rx.Single;
+import rx.observers.TestSubscriber;
 
 public class HystrixBuilderTest {
 
@@ -60,6 +65,109 @@ public class HystrixBuilderTest {
   }
 
   @Test
+  public void rxObservable() {
+    server.enqueue(new MockResponse().setBody("\"foo\""));
+
+    TestInterface api = target();
+
+    Observable<String> observable = api.observable();
+
+    assertThat(observable).isNotNull();
+    assertThat(server.getRequestCount()).isEqualTo(0);
+
+    TestSubscriber<String> testSubscriber = new TestSubscriber<String>();
+    observable.subscribe(testSubscriber);
+    testSubscriber.awaitTerminalEvent();
+    Assertions.assertThat(testSubscriber.getOnNextEvents().get(0)).isEqualTo("foo");
+  }
+
+  @Test
+  public void rxObservableInt() {
+    server.enqueue(new MockResponse().setBody("1"));
+
+    TestInterface api = target();
+
+    Observable<Integer> observable = api.intObservable();
+
+    assertThat(observable).isNotNull();
+    assertThat(server.getRequestCount()).isEqualTo(0);
+
+    TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>();
+    observable.subscribe(testSubscriber);
+    testSubscriber.awaitTerminalEvent();
+    Assertions.assertThat(testSubscriber.getOnNextEvents().get(0)).isEqualTo(new Integer(1));
+  }
+
+  @Test
+  public void rxObservableList() {
+    server.enqueue(new MockResponse().setBody("[\"foo\",\"bar\"]"));
+
+    TestInterface api = target();
+
+    Observable<List<String>> observable = api.listObservable();
+
+    assertThat(observable).isNotNull();
+    assertThat(server.getRequestCount()).isEqualTo(0);
+
+
+    TestSubscriber<List<String>> testSubscriber = new TestSubscriber<List<String>>();
+    observable.subscribe(testSubscriber);
+    testSubscriber.awaitTerminalEvent();
+    assertThat(testSubscriber.getOnNextEvents().get(0)).hasSize(2).contains("foo", "bar");
+  }
+
+  @Test
+  public void rxSingle() {
+    server.enqueue(new MockResponse().setBody("\"foo\""));
+
+    TestInterface api = target();
+
+    Single<String> single = api.single();
+
+    assertThat(single).isNotNull();
+    assertThat(server.getRequestCount()).isEqualTo(0);
+
+    TestSubscriber<String> testSubscriber = new TestSubscriber<String>();
+    single.subscribe(testSubscriber);
+    testSubscriber.awaitTerminalEvent();
+    Assertions.assertThat(testSubscriber.getOnNextEvents().get(0)).isEqualTo("foo");
+  }
+
+  @Test
+  public void rxSingleInt() {
+    server.enqueue(new MockResponse().setBody("1"));
+
+    TestInterface api = target();
+
+    Single<Integer> single = api.intSingle();
+
+    assertThat(single).isNotNull();
+    assertThat(server.getRequestCount()).isEqualTo(0);
+
+    TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>();
+    single.subscribe(testSubscriber);
+    testSubscriber.awaitTerminalEvent();
+    Assertions.assertThat(testSubscriber.getOnNextEvents().get(0)).isEqualTo(new Integer(1));
+  }
+
+  @Test
+  public void rxSingleList() {
+    server.enqueue(new MockResponse().setBody("[\"foo\",\"bar\"]"));
+
+    TestInterface api = target();
+
+    Single<List<String>> single = api.listSingle();
+
+    assertThat(single).isNotNull();
+    assertThat(server.getRequestCount()).isEqualTo(0);
+
+    TestSubscriber<List<String>> testSubscriber = new TestSubscriber<List<String>>();
+    single.subscribe(testSubscriber);
+    testSubscriber.awaitTerminalEvent();
+    assertThat(testSubscriber.getOnNextEvents().get(0)).hasSize(2).contains("foo", "bar");
+  }
+
+  @Test
   public void plainString() {
     server.enqueue(new MockResponse().setBody("\"foo\""));
 
@@ -100,6 +208,31 @@ public class HystrixBuilderTest {
     @RequestLine("GET /")
     @Headers("Accept: application/json")
     HystrixCommand<Integer> intCommand();
+
+    @RequestLine("GET /")
+    @Headers("Accept: application/json")
+    Observable<List<String>> listObservable();
+
+    @RequestLine("GET /")
+    @Headers("Accept: application/json")
+    Observable<String> observable();
+
+    @RequestLine("GET /")
+    @Headers("Accept: application/json")
+    Single<Integer> intSingle();
+
+    @RequestLine("GET /")
+    @Headers("Accept: application/json")
+    Single<List<String>> listSingle();
+
+    @RequestLine("GET /")
+    @Headers("Accept: application/json")
+    Single<String> single();
+
+    @RequestLine("GET /")
+    @Headers("Accept: application/json")
+    Observable<Integer> intObservable();
+
 
     @RequestLine("GET /")
     @Headers("Accept: application/json")


### PR DESCRIPTION
Support Observable return types by automatically calling `toObservable()`.  This makes it possible to declare a pure RxJava Feign API that is portable between the current Hystrix module and a future RxJava module.
