### PR TITLE
Handle invalid HTTP received from server

### DIFF
--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -15,6 +15,8 @@
  */
 package feign;
 
+import static java.lang.String.format;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -149,6 +151,12 @@ public interface Client {
     Response convertResponse(HttpURLConnection connection) throws IOException {
       int status = connection.getResponseCode();
       String reason = connection.getResponseMessage();
+
+      if (status < 0 || reason == null) {
+        // invalid response
+        throw new IOException(format("Invalid HTTP executing %s %s", connection.getRequestMethod(),
+            connection.getURL()));
+      }
 
       Map<String, Collection<String>> headers = new LinkedHashMap<String, Collection<String>>();
       for (Map.Entry<String, List<String>> field : connection.getHeaderFields().entrySet()) {


### PR DESCRIPTION
If response was empty it caused a NPE

```
java.lang.NullPointerException: reason
  at feign.Util.checkNotNull(Util.java:104)
  at feign.Response.<init>(Response.java:49)
  at feign.Response.create(Response.java:60)
  at feign.Client$Default.convertResponse(Client.java:171)
  at feign.Client$Default.execute(Client.java:72)
  at feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:95)
  at feign.SynchronousMethodHandler.invoke(SynchronousMethodHandler.java:74)
  at feign.ReflectiveFeign$FeignInvocationHandler.invoke(ReflectiveFeign.java:94)
```
