### PR TITLE
Apache HTTP client hates to have the Content-Length set

### DIFF
--- a/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
+++ b/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
@@ -118,10 +118,9 @@ public final class ApacheHttpClient implements Client {
         hasAcceptHeader = true;
       }
 
-      if (headerName.equalsIgnoreCase(Util.CONTENT_LENGTH) &&
-              requestBuilder.getHeaders(headerName) != null) {
-        //if the 'Content-Length' header is already present, it's been set from HttpEntity, so we
-        //won't add it again
+      if (headerName.equalsIgnoreCase(Util.CONTENT_LENGTH)) {
+        // The 'Content-Length' header is always set by the Apache client and it
+        // doesn't like us to set it as well.
         continue;
       }
 


### PR DESCRIPTION
It always sets the header itself and if we set it as well it barfs
so it is better just to avoid setting it at all.