### PR TITLE
make replacements header values work like in the body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Version 8.15
 * Supports PUT without a body parameter
+* Supports substitutions in `@Headers` like in `@Body`. (#326)
+  * **Note:** You might need to URL-encode literal values of `{` or `%` in your existing code.
 
 ### Version 8.14
 * Add support for RxJava Observable and Single return types via the `HystrixFeign` builder.

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -233,7 +233,7 @@ public interface Contract {
         if (annotationType == Param.class) {
           String name = ((Param) annotation).value();
           checkState(emptyToNull(name) != null, "Param annotation was empty on param %s.",
-                     paramIndex);
+              paramIndex);
           nameParam(data, name, paramIndex);
           if (annotationType == Param.class) {
             Class<? extends Param.Expander> expander = ((Param) annotation).expander();
@@ -244,8 +244,8 @@ public interface Contract {
           isHttpAnnotation = true;
           String varName = '{' + name + '}';
           if (data.template().url().indexOf(varName) == -1 &&
-              !searchMapValues(data.template().queries(), varName) &&
-              !searchMapValues(data.template().headers(), varName)) {
+              !searchMapValuesContainsExact(data.template().queries(), varName) &&
+              !searchMapValuesContainsSubstring(data.template().headers(), varName)) {
             data.formParams().add(name);
           }
         }
@@ -253,7 +253,8 @@ public interface Contract {
       return isHttpAnnotation;
     }
 
-    private static <K, V> boolean searchMapValues(Map<K, Collection<V>> map, V search) {
+    private static <K, V> boolean searchMapValuesContainsExact(Map<K, Collection<V>> map,
+                                                               V search) {
       Collection<Collection<V>> values = map.values();
       if (values == null) {
         return false;
@@ -262,6 +263,24 @@ public interface Contract {
       for (Collection<V> entry : values) {
         if (entry.contains(search)) {
           return true;
+        }
+      }
+
+      return false;
+    }
+
+    private static <K, V> boolean searchMapValuesContainsSubstring(Map<K, Collection<String>> map,
+                                                                   String search) {
+      Collection<Collection<String>> values = map.values();
+      if (values == null) {
+        return false;
+      }
+
+      for (Collection<String> entry : values) {
+        for (String value : entry) {
+          if (value.indexOf(search) != -1) {
+            return true;
+          }
         }
       }
 

--- a/core/src/main/java/feign/Headers.java
+++ b/core/src/main/java/feign/Headers.java
@@ -8,7 +8,7 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Expands headers supplied in the {@code value}.  Variables are permitted as values. <br>
+ * Expands headers supplied in the {@code value}.  Variables to the the right of the colon are expanded. <br>
  * <pre>
  * &#64;Headers("Content-Type: application/xml")
  * interface SoapApi {
@@ -24,9 +24,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * }) void post(&#64;Param("token") String token);
  * ...
  * </pre>
- * <br> <strong>Note:</strong> Headers do not overwrite each other. All headers with the same name
- * will be included in the request. <br><br><b>Relationship to JAXRS</b><br> <br> The following two
- * forms are identical. <br> Feign:
+ * <br> <strong>Notes:</strong>
+ * <ul>
+ *   <li>If you'd like curly braces literally in the header, urlencode them first.</li>
+ *   <li>Headers do not overwrite each other. All headers with the same name will be included
+ *   in the request.</li>
+ * </ul>
+ * <br><b>Relationship to JAXRS</b><br> <br> The following two forms are identical. <br><br> Feign:
  * <pre>
  * &#64;RequestLine("POST /")
  * &#64;Headers({

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -215,15 +215,8 @@ public final class RequestTemplate implements Serializable {
     for (String field : headers.keySet()) {
       Collection<String> resolvedValues = new ArrayList<String>();
       for (String value : valuesOrEmpty(headers, field)) {
-        String resolved;
-        if (value.indexOf('{') == 0) {
-          resolved = expand(value, unencoded);
-        } else {
-          resolved = value;
-        }
-        if (resolved != null) {
-          resolvedValues.add(resolved);
-        }
+        String resolved = urlDecode(expand(value, encoded));
+        resolvedValues.add(resolved);
       }
       resolvedHeaders.put(field, resolvedValues);
     }

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -143,6 +143,39 @@ public class RequestTemplateTest {
   }
 
   @Test
+  public void resolveTemplateWithHeaderSubstitutionsNotAtStart() {
+    RequestTemplate template = new RequestTemplate().method("GET")
+        .header("Authorization", "Bearer {token}");
+
+    template.resolve(mapOf("token", "1234"));
+
+    assertThat(template)
+        .hasHeaders(entry("Authorization", asList("Bearer 1234")));
+  }
+
+  @Test
+  public void resolveTemplateWithHeaderWithURLEncodedElements() {
+    RequestTemplate template = new RequestTemplate().method("GET")
+        .header("Encoded", "%7Bvar%7D");
+
+    template.resolve(mapOf("var", "1234"));
+
+    assertThat(template)
+        .hasHeaders(entry("Encoded", asList("{var}")));
+  }
+
+  @Test
+  public void resolveTemplateWithHeaderEmptyResult() {
+    RequestTemplate template = new RequestTemplate().method("GET")
+        .header("Encoded", "{var}");
+
+    template.resolve(mapOf("var", ""));
+
+    assertThat(template)
+        .hasHeaders(entry("Encoded", asList("")));
+  }
+
+  @Test
   public void resolveTemplateWithMixedRequestLineParams() throws Exception {
     RequestTemplate template = new RequestTemplate().method("GET")//
         .append("/domains/{domainId}/records")//


### PR DESCRIPTION
This tries to make replacement work in the headers like it works in the body. See #288 for a discussion. You might need to URL-encode literal values for `{` or `%` in your existing code.

Old behaviour:

````java
      @Headers("Authorization: {bearer}"
      // will replace -> Authorization: 37dahdbcpadf

      @Headers("Authorization: Bearer {bearer}")
      // will not replace -> Authorization: Bearer {bearer}

      @Headers("Authorization: Bearer %7Bbearer%7B")
      // will not url decode -> Authorization: Bearer %7Bbearer%7B

      @Headers("Authorization: %25"
      // will not url decode -> Authorization: %25````
````

New behavior

````java
      @Headers("Authorization: {bearer}"
      // will replace (AS BEFORE) -> Authorization: 37dahdbcpadf

      @Headers("Authorization: Bearer {bearer}")
      // WILL replace -> Authorization: Bearer 37dahdbcpadf

      @Headers("Authorization: %7Bbearer%7B"
      // WILL url decode-> Authorization: Bearer {bearer}

      @Headers("Authorization: %25"
      // WILL url decode -> Authorization: %
````

I've also added some test cases. This PR describes the behaviour I was expecting when using Headers for the first time. But it might be a breaking change for existing users, especially that curly braces now need to encoded if used literally.

Please feel free to comment and discuss, I will update the PR as necessary