### PR TITLE
refactor param expander instantiation

### DIFF
--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -24,6 +24,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import feign.Param.Expander;
+
+import static feign.Util.checkNotNull;
 import static feign.Util.checkState;
 import static feign.Util.emptyToNull;
 
@@ -312,4 +315,27 @@ public interface Contract {
       return result;
     }
   }
+
+  class DelegatingContract implements Contract, Param.Expander.Factory {
+    protected final Contract delegate;
+
+    public DelegatingContract(Contract delegate) {
+      super();
+      this.delegate = checkNotNull(delegate, "delegate");
+    }
+
+    @Override
+    public List<MethodMetadata> parseAndValidatateMetadata(Class<?> targetType) {
+      return this.delegate.parseAndValidatateMetadata(targetType);
+    }
+
+    @Override
+    public <E extends Expander> E getInstance(Class<E> expanderType) {
+      if (delegate instanceof Param.Expander.Factory) {
+          return ((Param.Expander.Factory) delegate).getInstance(expanderType);
+      }
+      return Param.DefaultExpanderFactory.INSTANCE.getInstance(expanderType);
+    }
+  }
+
 }

--- a/core/src/main/java/feign/Param.java
+++ b/core/src/main/java/feign/Param.java
@@ -44,6 +44,15 @@ public @interface Param {
      * Expands the value into a string. Does not accept or return null.
      */
     String expand(Object value);
+
+    interface Factory {
+      /**
+       * Called to create an instance of {@link feign.Param.Expander}.
+       * @param expanderType requested expander type
+       * @return E
+       */
+      <E extends Expander> E getInstance(Class<E> expanderType);
+    }
   }
 
   final class ToStringExpander implements Expander {
@@ -51,6 +60,21 @@ public @interface Param {
     @Override
     public String expand(Object value) {
       return value.toString();
+    }
+  }
+
+  final class DefaultExpanderFactory implements Expander.Factory {
+    public static final DefaultExpanderFactory INSTANCE = new DefaultExpanderFactory();
+
+    @Override
+    public <E extends Expander> E getInstance(Class<E> expanderType) {
+      try {
+        return expanderType.newInstance();
+      } catch (InstantiationException e) {
+        throw new IllegalStateException(e);
+      } catch (IllegalAccessException e) {
+        throw new IllegalStateException(e);
+      }
     }
   }
 }

--- a/hystrix/src/main/java/feign/hystrix/HystrixDelegatingContract.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixDelegatingContract.java
@@ -16,21 +16,19 @@ import rx.Single;
 /**
  * This special cases methods that return {@link HystrixCommand}, {@link Observable}, or {@link Single} so that they
  * are decoded properly.
- * 
+ *
  * <p>For example, {@literal HystrixCommand<Foo>} and {@literal Observable<Foo>} will decode {@code Foo}.
  */
 // Visible for use in custom Hystrix invocation handlers
-public final class HystrixDelegatingContract implements Contract {
-
-  private final Contract delegate;
+public final class HystrixDelegatingContract extends Contract.DelegatingContract {
 
   public HystrixDelegatingContract(Contract delegate) {
-    this.delegate = delegate;
+    super(delegate);
   }
 
   @Override
   public List<MethodMetadata> parseAndValidatateMetadata(Class<?> targetType) {
-    List<MethodMetadata> metadatas = this.delegate.parseAndValidatateMetadata(targetType);
+    List<MethodMetadata> metadatas = super.parseAndValidatateMetadata(targetType);
 
     for (MethodMetadata metadata : metadatas) {
       Type type = metadata.returnType();
@@ -49,4 +47,5 @@ public final class HystrixDelegatingContract implements Contract {
 
     return metadatas;
   }
+
 }


### PR DESCRIPTION
As discussed on feign's Gitter chat, a change like this would allow custom Feign `Contract` implementations to use alternate strategies for supplying `Param.Expander` instances.