### PR TITLE
Supports runtime injection of Param.Expander

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Version 8.16
 * Adds `@QueryMap` annotation to support dynamic query parameters
+* Supports runtime injection of `Param.Expander` via `MethodMetadata.indexToExpander`
 * Adds fallback support for HystrixCommand, Observable, and Single results
 
 ### Version 8.15

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,4 +7,5 @@ dependencies {
     testCompile 'org.assertj:assertj-core:1.7.1' // last version supporting JDK 7
     testCompile 'com.squareup.okhttp:mockwebserver:2.7.1'
     testCompile 'com.google.code.gson:gson:2.5' // for example
+    testCompile 'org.springframework:spring-context:4.2.5.RELEASE' // for example
 }

--- a/core/src/main/java/feign/MethodMetadata.java
+++ b/core/src/main/java/feign/MethodMetadata.java
@@ -22,8 +22,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 
 import feign.Param.Expander;
 
@@ -42,6 +40,7 @@ public final class MethodMetadata implements Serializable {
       new LinkedHashMap<Integer, Collection<String>>();
   private Map<Integer, Class<? extends Expander>> indexToExpanderClass =
       new LinkedHashMap<Integer, Class<? extends Expander>>();
+  private transient Map<Integer, Expander> indexToExpander;
 
   MethodMetadata() {
   }
@@ -118,7 +117,26 @@ public final class MethodMetadata implements Serializable {
     return indexToName;
   }
 
+  /**
+   * If {@link #indexToExpander} is null, classes here will be instantiated by newInstance.
+   */
   public Map<Integer, Class<? extends Expander>> indexToExpanderClass() {
     return indexToExpanderClass;
+  }
+
+  /**
+   * After {@link #indexToExpanderClass} is populated, this is set by contracts that support
+   * runtime injection.
+   */
+  public MethodMetadata indexToExpander(Map<Integer, Expander> indexToExpander) {
+    this.indexToExpander = indexToExpander;
+    return this;
+  }
+
+  /**
+   * When not null, this value will be used instead of {@link #indexToExpander()}.
+   */
+  public Map<Integer, Expander> indexToExpander() {
+    return indexToExpander;
   }
 }

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -162,6 +162,10 @@ public class ReflectiveFeign extends Feign {
 
     private BuildTemplateByResolvingArgs(MethodMetadata metadata) {
       this.metadata = metadata;
+      if (metadata.indexToExpander() != null) {
+        indexToExpander.putAll(metadata.indexToExpander());
+        return;
+      }
       if (metadata.indexToExpanderClass().isEmpty()) {
         return;
       }

--- a/core/src/test/java/feign/ContractWithRuntimeInjectionTest.java
+++ b/core/src/test/java/feign/ContractWithRuntimeInjectionTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign;
+
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static feign.assertj.MockWebServerAssertions.assertThat;
+
+public class ContractWithRuntimeInjectionTest {
+
+  static class CaseExpander implements Param.Expander {
+
+    private final boolean lowercase;
+
+    CaseExpander() {
+      this(false);
+    }
+
+    CaseExpander(boolean lowercase) {
+      this.lowercase = lowercase;
+    }
+
+
+    @Override
+    public String expand(Object value) {
+      return lowercase ? value.toString().toLowerCase() : value.toString();
+    }
+  }
+
+  @Rule
+  public final MockWebServer server = new MockWebServer();
+
+  interface TestExpander {
+
+    @RequestLine("GET /path?query={query}")
+    Response get(@Param(value = "query", expander = CaseExpander.class) String query);
+  }
+
+  @Test
+  public void baseCaseExpanderNewInstance() throws InterruptedException {
+    server.enqueue(new MockResponse());
+
+    String baseUrl = server.url("/default").toString();
+
+    Feign.builder().target(TestExpander.class, baseUrl).get("FOO");
+
+    assertThat(server.takeRequest()).hasPath("/default/path?query=FOO");
+  }
+
+  @Configuration
+  static class FeignConfiguration {
+
+    @Bean
+    CaseExpander lowercaseExpander() {
+      return new CaseExpander(true);
+    }
+
+    @Bean
+    Contract contract(BeanFactory beanFactory) {
+      return new ContractWithRuntimeInjection(beanFactory);
+    }
+  }
+
+  static class ContractWithRuntimeInjection extends Contract.Default {
+    final BeanFactory beanFactory;
+
+    ContractWithRuntimeInjection(BeanFactory beanFactory) {
+      this.beanFactory = beanFactory;
+    }
+
+    /**
+     * Injects {@link MethodMetadata#indexToExpander(Map)} via {@link BeanFactory#getBean(Class)}.
+     */
+    @Override
+    public List<MethodMetadata> parseAndValidatateMetadata(Class<?> targetType) {
+      List<MethodMetadata> result = super.parseAndValidatateMetadata(targetType);
+      for (MethodMetadata md : result) {
+        Map<Integer, Param.Expander> indexToExpander = new LinkedHashMap<Integer, Param.Expander>();
+        for (Map.Entry<Integer, Class<? extends Param.Expander>> entry : md.indexToExpanderClass().entrySet()) {
+          indexToExpander.put(entry.getKey(), beanFactory.getBean(entry.getValue()));
+        }
+        md.indexToExpander(indexToExpander);
+      }
+      return result;
+    }
+  }
+
+  @Test
+  public void contractWithRuntimeInjection() throws InterruptedException {
+    server.enqueue(new MockResponse());
+
+    String baseUrl = server.url("/default").toString();
+    ApplicationContext context = new AnnotationConfigApplicationContext(FeignConfiguration.class);
+
+    Feign.builder()
+        .contract(context.getBean(Contract.class))
+        .target(TestExpander.class, baseUrl).get("FOO");
+
+    assertThat(server.takeRequest()).hasPath("/default/path?query=foo");
+  }
+}


### PR DESCRIPTION
This supports runtime injection of Param.Expander. Implementing
contracts will assign `MethodMetadata.indexToExpander` using configured
values. When `MethodMetadata.indexToExpander` is unset, Feign has the
existing behavior, which is to newInstance each `indexToExpanderClass`.

Fixes #338