### PR TITLE
Adds commit log guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,20 @@ Please read [HACKING](./HACKING.md) prior to raising change.
 
 If you would like to contribute code you can do so through GitHub by forking the repository and sending a pull request (on a branch other than `master` or `gh-pages`).
 
+## Pull Requests
+Pull requests eventually need to resolve to a single commit. The commit log should be easy to read as a change log. We use the following form to accomplish that.
+* First line is a <=72 character description in present tense, explaining what this does.
+  * Ex. "Fixes regression on encoding vnd headers" > "Fixed encoding bug", which forces the reader to look at code to understand impact.
+* Do not include issue links in the first line as that makes pull requests look weird.
+  * Ex. "Addresses #345" becomes a pull request title: "Addresses #345 #346"
+* After the first line, use markdown to concisely summarize the implementation.
+  * This isn't in leiu of comments, and it assumes the reader isn't intimately familar with code structure.
+* If the change closes an issue, note that at the end of the commit description ex. "Fixes #345"
+  * GitHub will automatically close change with this syntax.
+* If the change is notable, also update the [change log](./CHANGELOG.md) with your summary description.
+  * The unreleased minor version is often a good default.
+
+## Code Style
 When submitting code, please ensure you follow the [Google Style Guide](http://google-styleguide.googlecode.com/svn/trunk/javaguide.html). For example, you can format code with IntelliJ 13 using [this file](https://google.github.io/styleguide/intellij-java-google-style.xml) and with IntelliJ 15 using [this file](https://raw.githubusercontent.com/garukun/styleguide/add-intellij-15-java/intellij-15-java-google-style.xml).
 
 ## License


### PR DESCRIPTION
I've noticed myself repeating instructions around the change log. This places guidance in the CONTRIBUTING section, as that's slightly more relevant than HACKING as it already includes policy such as license and code style.