### PR TITLE
Ignore static methods when validating interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: false     # default: false
 jdk:
-- oraclejdk7
+- oraclejdk8
 install: ./installViaTravis.sh
 script: ./buildViaTravis.sh
 cache:

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,3 +9,8 @@ dependencies {
     testCompile 'com.google.code.gson:gson:2.5' // for example
     testCompile 'org.springframework:spring-context:4.2.5.RELEASE' // for example
 }
+
+configure(compileTestJava) {
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+}

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -17,6 +17,7 @@ package feign;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,7 +56,8 @@ public interface Contract {
       }
       Map<String, MethodMetadata> result = new LinkedHashMap<String, MethodMetadata>();
       for (Method method : targetType.getMethods()) {
-        if (method.getDeclaringClass() == Object.class) {
+        if (method.getDeclaringClass() == Object.class ||
+            (method.getModifiers() & Modifier.STATIC) != 0) {
           continue;
         }
         MethodMetadata metadata = parseAndValidateMetadata(targetType, method);

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -693,4 +693,21 @@ public class DefaultContractTest {
 
     contract.parseAndValidatateMetadata(MissingMethod.class);
   }
+
+  interface StaticMethodOnInterface {
+    @RequestLine("GET /api/{key}")
+    String get(@Param("key") String key);
+
+    static String staticMethod() {
+      return "value";
+    }
+  }
+
+  @Test
+  public void staticMethodsOnInterfaceIgnored() throws Exception {
+    List<MethodMetadata> mds = contract.parseAndValidatateMetadata(StaticMethodOnInterface.class);
+    assertThat(mds).hasSize(1);
+    MethodMetadata md = mds.get(0);
+    assertThat(md.configKey()).isEqualTo("StaticMethodOnInterface#get(String)");
+  }
 }


### PR DESCRIPTION
This removes the check and exception for when static methods are found on an Interface being processed
fixes #312 