### PR TITLE
Exposes Encoder.MAP_STRING_WILDCARD to make form encoding easier

### DIFF
--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -263,7 +263,7 @@ public class ReflectiveFeign extends Feign {
         }
       }
       try {
-        encoder.encode(formVariables, Types.MAP_STRING_WILDCARD, mutable);
+        encoder.encode(formVariables, Encoder.MAP_STRING_WILDCARD, mutable);
       } catch (EncodeException e) {
         throw e;
       } catch (RuntimeException e) {

--- a/core/src/main/java/feign/Types.java
+++ b/core/src/main/java/feign/Types.java
@@ -34,14 +34,6 @@ import java.util.NoSuchElementException;
  */
 final class Types {
 
-  /**
-   * Type literal for {@code Map<String, ?>}.
-   */
-  static final Type MAP_STRING_WILDCARD = new ParameterizedTypeImpl(null, Map.class, String.class,
-                                                                    new WildcardTypeImpl(
-                                                                        new Type[]{Object.class},
-                                                                        new Type[]{}));
-
   private static final Type[] EMPTY_TYPE_ARRAY = new Type[0];
 
   private Types() {
@@ -313,7 +305,7 @@ final class Types {
     }
   }
 
-  private static final class ParameterizedTypeImpl implements ParameterizedType {
+  static final class ParameterizedTypeImpl implements ParameterizedType {
 
     private final Type ownerType;
     private final Type rawType;
@@ -409,7 +401,7 @@ final class Types {
    * support what the Java 6 language needs - at most one bound. If a lower bound is set, the upper
    * bound must be Object.class.
    */
-  private static final class WildcardTypeImpl implements WildcardType {
+  static final class WildcardTypeImpl implements WildcardType {
 
     private final Type upperBound;
     private final Type lowerBound;

--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -78,6 +78,14 @@ public class Util {
   public static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
   private static final int BUF_SIZE = 0x800; // 2K chars (4K bytes)
 
+
+  /**
+   * Type literal for {@code Map<String, ?>}.
+   */
+  public static final Type MAP_STRING_WILDCARD =
+      new Types.ParameterizedTypeImpl(null, Map.class, String.class,
+          new Types.WildcardTypeImpl(new Type[]{Object.class}, new Type[0]));
+
   private Util() { // no instances
   }
 

--- a/core/src/main/java/feign/codec/Encoder.java
+++ b/core/src/main/java/feign/codec/Encoder.java
@@ -18,6 +18,7 @@ package feign.codec;
 import java.lang.reflect.Type;
 
 import feign.RequestTemplate;
+import feign.Util;
 
 import static java.lang.String.format;
 
@@ -46,24 +47,28 @@ import static java.lang.String.format;
  * }
  * </pre>
  *
- * <p/> <h3>Form encoding</h3> <br> If any parameters are found in {@link
- * feign.MethodMetadata#formParams()}, they will be collected and passed to the Encoder as a {@code
- * Map<String, ?>}. <br>
+ * <p><h3>Form encoding</h3> <p>If any parameters are found in {@link
+ * feign.MethodMetadata#formParams()}, they will be collected and passed to the Encoder as a map.
+ *
+ * <p>Ex. The following is a form. Notice the parameters aren't consumed in the request line. A map
+ * including "username" and "password" keys will passed to the encoder, and the body type will be
+ * {@link #MAP_STRING_WILDCARD}.
  * <pre>
- * &#064;POST
- * &#064;Path(&quot;/&quot;)
+ * &#064;RequestLine(&quot;POST /&quot;)
  * Session login(@Param(&quot;username&quot;) String username, @Param(&quot;password&quot;) String
  * password);
  * </pre>
  */
 public interface Encoder {
+  /** Type literal for {@code Map<String, ?>}, indicating the object to encode is a form. */
+  Type MAP_STRING_WILDCARD = Util.MAP_STRING_WILDCARD;
 
   /**
    * Converts objects to an appropriate representation in the template.
    *
    * @param object   what to encode as the request body.
-   * @param bodyType the type the object should be encoded as. {@code Map<String, ?>}, if form
-   *                 encoding.
+   * @param bodyType the type the object should be encoded as. {@link #MAP_STRING_WILDCARD}
+   *                 indicates form encoding.
    * @param template the request template to populate.
    * @throws EncodeException when encoding failed due to a checked exception.
    */


### PR DESCRIPTION
Before, instructions around form encoding were incomplete, particularly
around how to get a hold of a `Map<String, ?>` type. This exposes
`Encoder.MAP_STRING_WILDCARD` to make form encoding easier.

Closes #259