### PR TITLE
bump okhttp dependencies to 2.7.5

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,7 +5,7 @@ sourceCompatibility = 1.6
 dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.1' // last version supporting JDK 7
-    testCompile 'com.squareup.okhttp:mockwebserver:2.7.1'
+    testCompile 'com.squareup.okhttp:mockwebserver:2.7.5'
     testCompile 'com.google.code.gson:gson:2.5' // for example
     testCompile 'org.springframework:spring-context:4.2.5.RELEASE' // for example
 }

--- a/httpclient/build.gradle
+++ b/httpclient/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     compile 'org.apache.httpcomponents:httpclient:4.5.1'
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.1' // last version supporting JDK 7
-    testCompile 'com.squareup.okhttp:mockwebserver:2.7.1'
+    testCompile 'com.squareup.okhttp:mockwebserver:2.7.5'
     testCompile project(':feign-core').sourceSets.test.output // for assertions
 }

--- a/hystrix/build.gradle
+++ b/hystrix/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compile 'com.netflix.hystrix:hystrix-core:1.4.21'
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.1' // last version supporting JDK 7
-    testCompile 'com.squareup.okhttp:mockwebserver:2.7.1'
+    testCompile 'com.squareup.okhttp:mockwebserver:2.7.5'
     testCompile project(':feign-gson')
     testCompile project(':feign-core').sourceSets.test.output // for assertions
 }

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -4,9 +4,9 @@ sourceCompatibility = 1.6
 
 dependencies {
     compile project(':feign-core')
-    compile 'com.squareup.okhttp:okhttp:2.7.1'
+    compile 'com.squareup.okhttp:okhttp:2.7.5'
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.1' // last version supporting JDK 7
-    testCompile 'com.squareup.okhttp:mockwebserver:2.7.1'
+    testCompile 'com.squareup.okhttp:mockwebserver:2.7.5'
     testCompile project(':feign-core').sourceSets.test.output // for assertions
 }

--- a/ribbon/build.gradle
+++ b/ribbon/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     compile 'com.netflix.ribbon:ribbon-loadbalancer:2.1.1'
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.1' // last version supporting JDK 7
-    testCompile 'com.squareup.okhttp:mockwebserver:2.7.1'
+    testCompile 'com.squareup.okhttp:mockwebserver:2.7.5'
     testCompile project(':feign-core').sourceSets.test.output
 }


### PR DESCRIPTION
bump due to: https://corner.squareup.com/2016/03/certificate-pinner-vulnerability.html