### PR TITLE
Allows for multiple inheritance in clients

### DIFF
--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -19,11 +19,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static feign.Util.checkState;
 import static feign.Util.emptyToNull;
@@ -47,13 +43,6 @@ public interface Contract {
     public List<MethodMetadata> parseAndValidatateMetadata(Class<?> targetType) {
       checkState(targetType.getTypeParameters().length == 0, "Parameterized types unsupported: %s",
                  targetType.getSimpleName());
-      checkState(targetType.getInterfaces().length <= 1, "Only single inheritance supported: %s",
-                 targetType.getSimpleName());
-      if (targetType.getInterfaces().length == 1) {
-        checkState(targetType.getInterfaces()[0].getInterfaces().length == 0,
-                   "Only single-level inheritance supported: %s",
-                   targetType.getSimpleName());
-      }
       Map<String, MethodMetadata> result = new LinkedHashMap<String, MethodMetadata>();
       for (Method method : targetType.getMethods()) {
         if (method.getDeclaringClass() == Object.class ||

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -499,21 +499,6 @@ public class DefaultContractTest {
     contract.parseAndValidatateMetadata(OverrideParameterizedApi.class);
   }
 
-  interface Child<T> extends SimpleParameterizedBaseApi<List<T>> {
-
-  }
-
-  interface GrandChild extends Child<String> {
-
-  }
-
-  @Test
-  public void onlySingleLevelInheritanceSupported() throws Exception {
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("Only single-level inheritance supported: GrandChild");
-    contract.parseAndValidatateMetadata(GrandChild.class);
-  }
-
   @Headers("Foo: Bar")
   interface ParameterizedBaseApi<K, M> {
 

--- a/core/src/test/java/feign/MultipleInheritanceTest.java
+++ b/core/src/test/java/feign/MultipleInheritanceTest.java
@@ -1,0 +1,64 @@
+package feign;
+
+import com.google.gson.Gson;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import static feign.assertj.MockWebServerAssertions.assertThat;
+
+public class MultipleInheritanceTest {
+
+    @Rule
+    public final MockWebServer server = new MockWebServer();
+
+    private final Multiple api = new Feign.Builder()
+        .decoder(new Decoder.Default())
+        .encoder(new Encoder() {
+            @Override
+            public void encode(Object object, Type bodyType, RequestTemplate template) {
+                if (object instanceof Map) {
+                    template.body(new Gson().toJson(object));
+                } else {
+                    template.body(object.toString());
+                }
+            }
+        }).target(Multiple.class, "http://localhost:" + server.getPort());
+
+    @Test
+    public void requestFromFirstInterface() throws Exception {
+        server.enqueue(new MockResponse().setBody("foo"));
+
+        api.first();
+
+        assertThat(server.takeRequest())
+            .hasPath("/first");
+    }
+    @Test
+    public void requestFromSecondInterface() throws Exception {
+        server.enqueue(new MockResponse().setBody("foo"));
+
+        api.second();
+
+        assertThat(server.takeRequest())
+            .hasPath("/second");
+    }
+
+    private interface Multiple extends First, Second {}
+
+    interface First {
+        @RequestLine("GET /first")
+        Response first();
+    }
+
+    interface Second {
+        @RequestLine("GET /second")
+        Response second();
+    }
+}


### PR DESCRIPTION
In `feign.Client` lines 51 through 56, there were checks to ensure no multiple inheritance in interfaces used to build clients. After removing those lines it turned out, that multiple inheritance actually works just fine. To ensure that, I've added a test class `MultipleInheratanceTest`.