### PR TITLE
Fixes dispatch for toString, equals, hashCode in hystrix

### DIFF
--- a/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
@@ -22,7 +22,8 @@ import com.netflix.hystrix.HystrixCommandKey;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.HashMap;
+import java.lang.reflect.Proxy;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import feign.InvocationHandlerFactory;
@@ -56,7 +57,7 @@ final class HystrixInvocationHandler implements InvocationHandler {
    * @return cached methods map for fallback invoking
    */
   private Map<Method, Method> toFallbackMethod(Map<Method, MethodHandler> dispatch) {
-    Map<Method, Method> result = new HashMap<Method, Method>();
+    Map<Method, Method> result = new LinkedHashMap<Method, Method>();
     for (Method method : dispatch.keySet()) {
       method.setAccessible(true);
       result.put(method, method);
@@ -67,6 +68,22 @@ final class HystrixInvocationHandler implements InvocationHandler {
   @Override
   public Object invoke(final Object proxy, final Method method, final Object[] args)
       throws Throwable {
+    // early exit if the invoked method is from java.lang.Object
+    // code is the same as ReflectiveFeign.FeignInvocationHandler
+    if ("equals".equals(method.getName())) {
+      try {
+        Object otherHandler =
+            args.length > 0 && args[0] != null ? Proxy.getInvocationHandler(args[0]) : null;
+        return equals(otherHandler);
+      } catch (IllegalArgumentException e) {
+        return false;
+      }
+    } else if ("hashCode".equals(method.getName())) {
+      return hashCode();
+    } else if ("toString".equals(method.getName())) {
+      return toString();
+    }
+
     String groupKey = this.target.name();
     String commandKey = method.getName();
     HystrixCommand.Setter setter = HystrixCommand.Setter
@@ -135,6 +152,25 @@ final class HystrixInvocationHandler implements InvocationHandler {
 
   private boolean isReturnsSingle(Method method) {
     return Single.class.isAssignableFrom(method.getReturnType());
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof HystrixInvocationHandler) {
+      HystrixInvocationHandler other = (HystrixInvocationHandler) obj;
+      return target.equals(other.target);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return target.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return target.toString();
   }
 
   static final class Factory implements InvocationHandlerFactory {


### PR DESCRIPTION
This copies missing logic from `FeignInvocationHandler` to
`HystrixInvocationHandler`, preventing NPEs when calling methods defined
on `java.lang.Object`.

Fixes #332