### PR TITLE
Added rx.Completable support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 8.17
+* Adds support to RxJava Completable via `HystrixFeign` builder with fallback support
+* Upgraded hystrix-core to 1.4.26
+
 ### Version 8.16
 * Adds `@HeaderMap` annotation to support dynamic header fields and values
 * Add support for default and static methods on interfaces

--- a/hystrix/build.gradle
+++ b/hystrix/build.gradle
@@ -4,7 +4,7 @@ sourceCompatibility = 1.6
 
 dependencies {
     compile project(':feign-core')
-    compile 'com.netflix.hystrix:hystrix-core:1.4.21'
+    compile 'com.netflix.hystrix:hystrix-core:1.4.26'
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.1' // last version supporting JDK 7
     testCompile 'com.squareup.okhttp:mockwebserver:2.7.5'

--- a/hystrix/src/main/java/feign/hystrix/HystrixDelegatingContract.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixDelegatingContract.java
@@ -10,6 +10,7 @@ import com.netflix.hystrix.HystrixCommand;
 
 import feign.Contract;
 import feign.MethodMetadata;
+import rx.Completable;
 import rx.Observable;
 import rx.Single;
 
@@ -44,6 +45,8 @@ public final class HystrixDelegatingContract implements Contract {
       } else if (type instanceof ParameterizedType && ((ParameterizedType) type).getRawType().equals(Single.class)) {
         Type actualType = resolveLastTypeParameter(type, Single.class);
         metadata.returnType(actualType);
+      } else if (type instanceof ParameterizedType && ((ParameterizedType) type).getRawType().equals(Completable.class)) {
+        metadata.returnType(void.class);
       }
     }
 

--- a/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import feign.InvocationHandlerFactory;
 import feign.InvocationHandlerFactory.MethodHandler;
 import feign.Target;
+import rx.Completable;
 import rx.Observable;
 import rx.Single;
 
@@ -100,6 +101,9 @@ final class HystrixInvocationHandler implements InvocationHandler {
           } else if (isReturnsSingle(method)) {
             // Create a cold Observable as a Single
             return ((Single) result).toObservable().toBlocking().first();
+          } else if (isReturnsCompletable(method)) {
+            ((Completable) result).await();
+            return null;
           } else {
             return result;
           }
@@ -121,8 +125,14 @@ final class HystrixInvocationHandler implements InvocationHandler {
     } else if (isReturnsSingle(method)) {
       // Create a cold Observable as a Single
       return hystrixCommand.toObservable().toSingle();
+    } else if(isReturnsCompletable(method)) {
+      return hystrixCommand.toObservable().toCompletable();
     }
     return hystrixCommand.execute();
+  }
+
+  private boolean isReturnsCompletable(Method method) {
+    return Completable.class.isAssignableFrom(method.getReturnType());
   }
 
   private boolean isReturnsHystrixCommand(Method method) {

--- a/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
+++ b/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
@@ -21,6 +21,7 @@ import feign.Headers;
 import feign.Param;
 import feign.RequestLine;
 import feign.gson.GsonDecoder;
+import rx.Completable;
 import rx.Observable;
 import rx.Single;
 import rx.observers.TestSubscriber;
@@ -383,6 +384,81 @@ public class HystrixBuilderTest {
   }
 
   @Test
+  public void rxCompletableEmptyBody() {
+    server.enqueue(new MockResponse());
+
+    TestInterface api = target();
+
+    Completable completable = api.completable();
+
+    assertThat(completable).isNotNull();
+    assertThat(server.getRequestCount()).isEqualTo(0);
+
+    TestSubscriber<String> testSubscriber = new TestSubscriber<String>();
+    completable.subscribe(testSubscriber);
+    testSubscriber.awaitTerminalEvent();
+
+    testSubscriber.assertCompleted();
+    testSubscriber.assertNoErrors();
+  }
+
+  @Test
+  public void rxCompletableWithBody() {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    TestInterface api = target();
+
+    Completable completable = api.completable();
+
+    assertThat(completable).isNotNull();
+    assertThat(server.getRequestCount()).isEqualTo(0);
+
+    TestSubscriber<String> testSubscriber = new TestSubscriber<String>();
+    completable.subscribe(testSubscriber);
+    testSubscriber.awaitTerminalEvent();
+
+    testSubscriber.assertCompleted();
+    testSubscriber.assertNoErrors();
+  }
+
+  @Test
+  public void rxCompletableFailWithoutFallback() {
+    server.enqueue(new MockResponse().setResponseCode(500));
+
+    TestInterface api = HystrixFeign.builder()
+        .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    Completable completable = api.completable();
+
+    assertThat(completable).isNotNull();
+    assertThat(server.getRequestCount()).isEqualTo(0);
+
+    TestSubscriber<String> testSubscriber = new TestSubscriber<String>();
+    completable.subscribe(testSubscriber);
+    testSubscriber.awaitTerminalEvent();
+
+    testSubscriber.assertError(HystrixRuntimeException.class);
+  }
+
+  @Test
+  public void rxCompletableFallback() {
+    server.enqueue(new MockResponse().setResponseCode(500));
+
+    TestInterface api = target();
+
+    Completable completable = api.completable();
+
+    assertThat(completable).isNotNull();
+    assertThat(server.getRequestCount()).isEqualTo(0);
+
+    TestSubscriber<String> testSubscriber = new TestSubscriber<String>();
+    completable.subscribe(testSubscriber);
+    testSubscriber.awaitTerminalEvent();
+
+    testSubscriber.assertCompleted();
+  }
+
+  @Test
   public void plainString() {
     server.enqueue(new MockResponse().setBody("\"foo\""));
 
@@ -479,6 +555,9 @@ public class HystrixBuilderTest {
     @RequestLine("GET /")
     @Headers("Accept: application/json")
     List<String> getList();
+
+    @RequestLine("GET /")
+    Completable completable();
   }
 
   class FallbackTestInterface implements TestInterface {
@@ -558,6 +637,11 @@ public class HystrixBuilderTest {
       List<String> fallbackResult = new ArrayList<String>();
       fallbackResult.add("fallback");
       return fallbackResult;
+    }
+
+    @Override
+    public Completable completable() {
+      return Completable.complete();
     }
   }
 }


### PR DESCRIPTION
- Added ```rx.Completable``` support
- Upgraded hystrix-core to have a newer version of rxjava with ```Completable``` in theory it can be upgraded to 1.5.x as it should be backward compatible.

Fixes #379