### PR TITLE
Upgrade to OkHttp 3.2 and adjust tests to work with new version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 8.18
+* Upgrades dependency version for OkHttp/MockWebServer 3.2.0
+
 ### Version 8.17
 * Adds support to RxJava Completable via `HystrixFeign` builder with fallback support
 * Upgraded hystrix-core to 1.4.26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
-### Version 8.18
-* Upgrades dependency version for OkHttp/MockWebServer 3.2.0
-
 ### Version 8.17
 * Adds support to RxJava Completable via `HystrixFeign` builder with fallback support
 * Upgraded hystrix-core to 1.4.26
+* Upgrades dependency version for OkHttp/MockWebServer 3.2.0
 
 ### Version 8.16
 * Adds `@HeaderMap` annotation to support dynamic header fields and values

--- a/benchmark/src/main/java/feign/benchmark/RealRequestBenchmarks.java
+++ b/benchmark/src/main/java/feign/benchmark/RealRequestBenchmarks.java
@@ -1,7 +1,7 @@
 package feign.benchmark;
 
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile 'org.jvnet:animal-sniffer-annotation:1.0'
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.1' // last version supporting JDK 7
-    testCompile 'com.squareup.okhttp:mockwebserver:2.7.5'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.2.0'
     testCompile 'com.google.code.gson:gson:2.5' // for example
     testCompile 'org.springframework:spring-context:4.2.5.RELEASE' // for example
 }

--- a/core/src/test/java/feign/BaseApiTest.java
+++ b/core/src/test/java/feign/BaseApiTest.java
@@ -17,8 +17,8 @@ package feign;
 
 import com.google.gson.reflect.TypeToken;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -69,7 +69,7 @@ public class BaseApiTest {
   public void resolvesParameterizedResult() throws InterruptedException {
     server.enqueue(new MockResponse().setBody("foo"));
 
-    String baseUrl = server.getUrl("/default").toString();
+    String baseUrl = server.url("/default").toString();
 
     Feign.builder()
         .decoder(new Decoder() {
@@ -90,7 +90,7 @@ public class BaseApiTest {
   public void resolvesBodyParameter() throws InterruptedException {
     server.enqueue(new MockResponse().setBody("foo"));
 
-    String baseUrl = server.getUrl("/default").toString();
+    String baseUrl = server.url("/default").toString();
 
     Feign.builder()
         .encoder(new Encoder() {

--- a/core/src/test/java/feign/ContractWithRuntimeInjectionTest.java
+++ b/core/src/test/java/feign/ContractWithRuntimeInjectionTest.java
@@ -15,8 +15,8 @@
  */
 package feign;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/core/src/test/java/feign/FeignBuilderTest.java
+++ b/core/src/test/java/feign/FeignBuilderTest.java
@@ -15,8 +15,8 @@
  */
 package feign;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -18,9 +18,9 @@ package feign;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.SocketPolicy;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.SocketPolicy;
+import okhttp3.mockwebserver.MockWebServer;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;

--- a/core/src/test/java/feign/LoggerTest.java
+++ b/core/src/test/java/feign/LoggerTest.java
@@ -15,8 +15,8 @@
  */
 package feign;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.Rule;
@@ -105,7 +105,7 @@ public class LoggerTest {
       SendsStuff api = Feign.builder()
           .logger(logger)
           .logLevel(logLevel)
-          .target(SendsStuff.class, "http://localhost:" + server.getUrl("").getPort());
+          .target(SendsStuff.class, "http://localhost:" + server.getPort());
 
       api.login("netflix", "denominator", "password");
     }
@@ -137,7 +137,7 @@ public class LoggerTest {
       SendsStuff api = Feign.builder()
           .logger(logger)
           .logLevel(logLevel)
-          .target(SendsStuff.class, "http://localhost:" + server.getUrl("").getPort());
+          .target(SendsStuff.class, "http://localhost:" + server.getPort());
 
       api.login("netflix", "denominator", "password");
     }
@@ -194,7 +194,7 @@ public class LoggerTest {
           .logger(logger)
           .logLevel(logLevel)
           .options(new Request.Options(10 * 1000, 50))
-          .target(SendsStuff.class, "http://localhost:" + server.getUrl("").getPort());
+          .target(SendsStuff.class, "http://localhost:" + server.getPort());
 
       api.login("netflix", "denominator", "password");
     }

--- a/core/src/test/java/feign/TargetTest.java
+++ b/core/src/test/java/feign/TargetTest.java
@@ -15,8 +15,8 @@
  */
 package feign;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,7 +40,7 @@ public class TargetTest {
   public void baseCaseQueryParamsArePercentEncoded() throws InterruptedException {
     server.enqueue(new MockResponse());
 
-    String baseUrl = server.getUrl("/default").toString();
+    String baseUrl = server.url("/default").toString();
 
     Feign.builder().target(TestQuery.class, baseUrl).get("slash/foo", "slash/bar");
 
@@ -55,7 +55,7 @@ public class TargetTest {
   public void targetCanCreateCustomRequest() throws InterruptedException {
     server.enqueue(new MockResponse());
 
-    String baseUrl = server.getUrl("/default").toString();
+    String baseUrl = server.url("/default").toString();
     Target<TestQuery> custom = new HardCodedTarget<TestQuery>(TestQuery.class, baseUrl) {
 
       @Override

--- a/core/src/test/java/feign/assertj/MockWebServerAssertions.java
+++ b/core/src/test/java/feign/assertj/MockWebServerAssertions.java
@@ -15,7 +15,7 @@
  */
 package feign.assertj;
 
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.RecordedRequest;
 
 import org.assertj.core.api.Assertions;
 

--- a/core/src/test/java/feign/assertj/RecordedRequestAssert.java
+++ b/core/src/test/java/feign/assertj/RecordedRequestAssert.java
@@ -15,8 +15,8 @@
  */
 package feign.assertj;
 
-import com.squareup.okhttp.Headers;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import okhttp3.Headers;
+import okhttp3.mockwebserver.RecordedRequest;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.data.MapEntry;

--- a/core/src/test/java/feign/client/DefaultClientTest.java
+++ b/core/src/test/java/feign/client/DefaultClientTest.java
@@ -15,9 +15,9 @@
  */
 package feign.client;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.SocketPolicy;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.SocketPolicy;
+import okhttp3.mockwebserver.MockWebServer;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/httpclient/build.gradle
+++ b/httpclient/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     compile 'org.apache.httpcomponents:httpclient:4.5.1'
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.1' // last version supporting JDK 7
-    testCompile 'com.squareup.okhttp:mockwebserver:2.7.5'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.2.0'
     testCompile project(':feign-core').sourceSets.test.output // for assertions
 }

--- a/httpclient/src/test/java/feign/httpclient/ApacheHttpClientTest.java
+++ b/httpclient/src/test/java/feign/httpclient/ApacheHttpClientTest.java
@@ -15,8 +15,8 @@
  */
 package feign.httpclient;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/hystrix/build.gradle
+++ b/hystrix/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compile 'com.netflix.hystrix:hystrix-core:1.4.26'
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.1' // last version supporting JDK 7
-    testCompile 'com.squareup.okhttp:mockwebserver:2.7.5'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.2.0'
     testCompile project(':feign-gson')
     testCompile project(':feign-core').sourceSets.test.output // for assertions
 }

--- a/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
+++ b/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
@@ -3,8 +3,8 @@ package feign.hystrix;
 import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
 import com.netflix.hystrix.exception.HystrixRuntimeException;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Rule;

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -4,9 +4,9 @@ sourceCompatibility = 1.6
 
 dependencies {
     compile project(':feign-core')
-    compile 'com.squareup.okhttp:okhttp:2.7.5'
+    compile 'com.squareup.okhttp3:okhttp:3.2.0'
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.1' // last version supporting JDK 7
-    testCompile 'com.squareup.okhttp:mockwebserver:2.7.5'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.2.0'
     testCompile project(':feign-core').sourceSets.test.output // for assertions
 }

--- a/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
@@ -15,12 +15,12 @@
  */
 package feign.okhttp;
 
-import com.squareup.okhttp.Headers;
-import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
-import com.squareup.okhttp.Response;
-import com.squareup.okhttp.ResponseBody;
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -41,13 +41,13 @@ import feign.Client;
  */
 public final class OkHttpClient implements Client {
 
-  private final com.squareup.okhttp.OkHttpClient delegate;
+  private final okhttp3.OkHttpClient delegate;
 
   public OkHttpClient() {
-    this(new com.squareup.okhttp.OkHttpClient());
+    this(new okhttp3.OkHttpClient());
   }
 
-  public OkHttpClient(com.squareup.okhttp.OkHttpClient delegate) {
+  public OkHttpClient(okhttp3.OkHttpClient delegate) {
     this.delegate = delegate;
   }
 
@@ -141,12 +141,13 @@ public final class OkHttpClient implements Client {
   @Override
   public feign.Response execute(feign.Request input, feign.Request.Options options)
       throws IOException {
-    com.squareup.okhttp.OkHttpClient requestScoped;
-    if (delegate.getConnectTimeout() != options.connectTimeoutMillis()
-        || delegate.getReadTimeout() != options.readTimeoutMillis()) {
-      requestScoped = delegate.clone();
-      requestScoped.setConnectTimeout(options.connectTimeoutMillis(), TimeUnit.MILLISECONDS);
-      requestScoped.setReadTimeout(options.readTimeoutMillis(), TimeUnit.MILLISECONDS);
+    okhttp3.OkHttpClient requestScoped;
+    if (delegate.connectTimeoutMillis() != options.connectTimeoutMillis()
+        || delegate.readTimeoutMillis() != options.readTimeoutMillis()) {
+       requestScoped = delegate.newBuilder()
+               .connectTimeout(options.connectTimeoutMillis(), TimeUnit.MILLISECONDS)
+               .readTimeout(options.readTimeoutMillis(), TimeUnit.MILLISECONDS)
+               .build();
     } else {
       requestScoped = delegate;
     }

--- a/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
+++ b/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
@@ -15,8 +15,8 @@
  */
 package feign.okhttp;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/ribbon/build.gradle
+++ b/ribbon/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     compile 'com.netflix.ribbon:ribbon-loadbalancer:2.1.1'
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.1' // last version supporting JDK 7
-    testCompile 'com.squareup.okhttp:mockwebserver:2.7.5'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.2.0'
     testCompile project(':feign-core').sourceSets.test.output
 }

--- a/ribbon/src/test/java/feign/ribbon/LoadBalancingTargetTest.java
+++ b/ribbon/src/test/java/feign/ribbon/LoadBalancingTargetTest.java
@@ -15,8 +15,8 @@
  */
 package feign.ribbon;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -51,8 +51,8 @@ public class LoadBalancingTargetTest {
     server2.enqueue(new MockResponse().setBody("success!"));
 
     getConfigInstance().setProperty(serverListKey,
-                                    hostAndPort(server1.getUrl("")) + "," + hostAndPort(
-                                        server2.getUrl("")));
+                                    hostAndPort(server1.url("").url()) + "," + hostAndPort(
+                                        server2.url("").url()));
 
     try {
       LoadBalancingTarget<TestInterface>

--- a/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
+++ b/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
@@ -31,9 +31,9 @@ import org.junit.rules.TestName;
 
 import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.client.config.IClientConfig;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.SocketPolicy;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.SocketPolicy;
+import okhttp3.mockwebserver.MockWebServer;
 
 import feign.Client;
 import feign.Feign;
@@ -62,8 +62,8 @@ public class RibbonClientTest {
     server2.enqueue(new MockResponse().setBody("success!"));
 
     getConfigInstance().setProperty(serverListKey(),
-                                    hostAndPort(server1.getUrl("")) + "," + hostAndPort(
-                                        server2.getUrl("")));
+                                    hostAndPort(server1.url("").url()) + "," + hostAndPort(
+                                        server2.url("").url()));
 
     TestInterface
         api =
@@ -84,7 +84,7 @@ public class RibbonClientTest {
     server1.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
     server1.enqueue(new MockResponse().setBody("success!"));
 
-    getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.getUrl("")));
+    getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.url("").url()));
 
     TestInterface
         api =
@@ -112,7 +112,7 @@ public class RibbonClientTest {
 
     server1.enqueue(new MockResponse().setBody("success!"));
 
-    getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.getUrl("")));
+    getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.url("").url()));
 
     TestInterface
         api =
@@ -135,7 +135,7 @@ public class RibbonClientTest {
     server1.useHttps(TrustingSSLSocketFactory.get("localhost"), false);
     server1.enqueue(new MockResponse().setBody("success!"));
 
-    getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.getUrl("")));
+    getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.url("").url()));
 
     TestInterface api =
         Feign.builder().client(RibbonClient.builder().delegate(trustSSLSockets).build())
@@ -150,7 +150,7 @@ public class RibbonClientTest {
     server1.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
     server1.enqueue(new MockResponse().setBody("success!"));
 
-    getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.getUrl("")));
+    getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.url("").url()));
 
     TestInterface api =
         Feign.builder().client(RibbonClient.create())


### PR DESCRIPTION
Upgrading to OkHttp3 will allow applications with Netflix-Feign to use enhanced OkHttpClient capabilities, especially the newly introduced [Builder method](https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.Builder.html).

In addition to import and compile statement changes, method name changes were needed in multiple tests to work with the new dependency version.  In the OkHttpClient class, clone() was replaced with newBuilder() as a way to change client settings. 