### PR TITLE
Add support for expansion of @Param lists

### DIFF
--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -227,8 +227,6 @@ public class ReflectiveFeign extends Feign {
     private Object expandElements(Expander expander, Object value) {
       if (value instanceof Iterable) {
         return expandIterable(expander, (Iterable) value);
-      } else if (value.getClass().isArray()) {
-        return expandIterable(expander, Arrays.asList((Object[])value));
       }
       return expander.expand(value);
     }
@@ -236,9 +234,7 @@ public class ReflectiveFeign extends Feign {
     private List<String> expandIterable(Expander expander, Iterable value) {
       List<String> values = new ArrayList<String>();
       for (Object element : (Iterable) value) {
-        if (element==null) {
-          values.add("");
-        } else {
+        if (element!=null) {
           values.add(expander.expand(element));
         }
       }

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -202,7 +202,7 @@ public class ReflectiveFeign extends Feign {
         Object value = argv[entry.getKey()];
         if (value != null) { // Null values are skipped.
           if (indexToExpander.containsKey(i)) {
-            value = indexToExpander.get(i).expand(value);
+            value = expandElements(indexToExpander.get(i), value);
           }
           for (String name : entry.getValue()) {
             varBuilder.put(name, value);
@@ -222,6 +222,27 @@ public class ReflectiveFeign extends Feign {
       }
 
       return template;
+    }
+
+    private Object expandElements(Expander expander, Object value) {
+      if (value instanceof Collection) {
+        return expandCollection(expander, (Collection) value);
+      } else if (value.getClass().isArray()) {
+        return expandCollection(expander, Arrays.asList((Object[])value));
+      }
+      return expander.expand(value);
+    }
+
+    private List<String> expandCollection(Expander expander, Collection value) {
+      List<String> values = new ArrayList<String>();
+      for (Object element : (Collection) value) {
+        if (element==null) {
+          values.add("");
+        } else {
+          values.add(expander.expand(element));
+        }
+      }
+      return values;
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -225,17 +225,17 @@ public class ReflectiveFeign extends Feign {
     }
 
     private Object expandElements(Expander expander, Object value) {
-      if (value instanceof Collection) {
-        return expandCollection(expander, (Collection) value);
+      if (value instanceof Iterable) {
+        return expandIterable(expander, (Iterable) value);
       } else if (value.getClass().isArray()) {
-        return expandCollection(expander, Arrays.asList((Object[])value));
+        return expandIterable(expander, Arrays.asList((Object[])value));
       }
       return expander.expand(value);
     }
 
-    private List<String> expandCollection(Expander expander, Collection value) {
+    private List<String> expandIterable(Expander expander, Iterable value) {
       List<String> values = new ArrayList<String>();
-      for (Object element : (Collection) value) {
+      for (Object element : (Iterable) value) {
         if (element==null) {
           values.add("");
         } else {

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -242,6 +242,18 @@ public class FeignTest {
   }
 
   @Test
+  public void customExpanderNullParam() throws Exception {
+    server.enqueue(new MockResponse());
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    api.expandArray(new Date[] {new Date(1234l), null});
+
+    assertThat(server.takeRequest())
+        .hasPath("/?date=1234&date=");
+  }
+
+  @Test
   public void headerMap() throws Exception {
     server.enqueue(new MockResponse());
 

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -230,27 +230,15 @@ public class FeignTest {
   }
 
   @Test
-  public void customExpanderArrayParam() throws Exception {
-    server.enqueue(new MockResponse());
-
-    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
-
-    api.expandArray(new Date[] {new Date(1234l), new Date(12345l)});
-
-    assertThat(server.takeRequest())
-        .hasPath("/?date=1234&date=12345");
-  }
-
-  @Test
   public void customExpanderNullParam() throws Exception {
     server.enqueue(new MockResponse());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
-    api.expandArray(new Date[] {new Date(1234l), null});
+    api.expandList(Arrays.asList(new Date(1234l), null));
 
     assertThat(server.takeRequest())
-        .hasPath("/?date=1234&date=");
+        .hasPath("/?date=1234");
   }
 
   @Test

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -223,10 +223,22 @@ public class FeignTest {
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
-    api.expandList(Arrays.asList(new Date(1234l)));
+    api.expandList(Arrays.asList(new Date(1234l), new Date(12345l)));
 
     assertThat(server.takeRequest())
-        .hasPath("/?date=1234");
+        .hasPath("/?date=1234&date=12345");
+  }
+
+  @Test
+  public void customExpanderArrayParam() throws Exception {
+    server.enqueue(new MockResponse());
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    api.expandArray(new Date[] {new Date(1234l), new Date(12345l)});
+
+    assertThat(server.takeRequest())
+        .hasPath("/?date=1234&date=12345");
   }
 
   @Test
@@ -670,6 +682,9 @@ public class FeignTest {
 
     @RequestLine("GET /?date={date}")
     void expandList(@Param(value = "date", expander = DateToMillis.class) List<Date> dates);
+
+    @RequestLine("GET /?date={date}")
+    void expandArray(@Param(value = "date", expander = DateToMillis.class) Date[] dates);
 
     @RequestLine("GET /")
     void headerMap(@HeaderMap Map<String, Object> headerMap);

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -218,6 +218,18 @@ public class FeignTest {
   }
 
   @Test
+  public void customExpanderListParam() throws Exception {
+    server.enqueue(new MockResponse());
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    api.expandList(Arrays.asList(new Date(1234l)));
+
+    assertThat(server.takeRequest())
+        .hasPath("/?date=1234");
+  }
+
+  @Test
   public void headerMap() throws Exception {
     server.enqueue(new MockResponse());
 
@@ -655,6 +667,9 @@ public class FeignTest {
 
     @RequestLine("POST /?date={date}")
     void expand(@Param(value = "date", expander = DateToMillis.class) Date date);
+
+    @RequestLine("GET /?date={date}")
+    void expandList(@Param(value = "date", expander = DateToMillis.class) List<Date> dates);
 
     @RequestLine("GET /")
     void headerMap(@HeaderMap Map<String, Object> headerMap);


### PR DESCRIPTION
The existing support for expanders in method parameters is
limited to converting a single value. The change applies the
expander individually to each item in a collection or array,
thus making it useful for multi-valued query parameters, for
instance. The old behaviour is preserved because no existing
expanders would have been converting collections to strings
(probably).