### PR TITLE
Fixed clearing query param with unsafe characters in name

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -306,13 +306,14 @@ public final class RequestTemplate implements Serializable {
    * @see #queries()
    */
   public RequestTemplate query(String name, String... values) {
-    queries.remove(checkNotNull(name, "name"));
+    String encodedName = encodeIfNotVariable(checkNotNull(name, "name"));
+    queries.remove(encodedName);
     if (values != null && values.length > 0 && values[0] != null) {
       ArrayList<String> encoded = new ArrayList<String>();
       for (String value : values) {
         encoded.add(encodeIfNotVariable(value));
       }
-      this.queries.put(encodeIfNotVariable(name), encoded);
+      this.queries.put(encodedName, encoded);
     }
     return this;
   }

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -332,4 +332,15 @@ public class RequestTemplateTest {
 
     new RequestTemplate().method("/path?queryParam={queryParam}");
   }
+
+  @Test
+  public void encodedQueryClearedOnNull() throws Exception {
+    RequestTemplate template = new RequestTemplate();
+
+    template.query("param[]", "value");
+    assertThat(template).hasQueries(entry("param[]", asList("value")));
+
+    template.query("param[]", (String[]) null);
+    assertThat(template.queries()).isEmpty();
+  }
 }


### PR DESCRIPTION
queries map uses encoded names as keys, but unencoded name was passed to `remove()`